### PR TITLE
Pass clicks through transparent overlay margins

### DIFF
--- a/glance/NotchOverlay/NotchInteractionRegion.swift
+++ b/glance/NotchOverlay/NotchInteractionRegion.swift
@@ -1,0 +1,40 @@
+import AppKit
+import SwiftUI
+
+/// A non-drawing view laid out with the visible panel, before its shadow.
+/// Its bounds follow SwiftUI's size and position animations, so transparent
+/// margins and rounded corners never become an interactive rectangle.
+struct NotchInteractionRegion: NSViewRepresentable, Animatable {
+    var shape: NotchShape
+    var onHover: (Bool) -> Void
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { shape.animatableData }
+        set { shape.animatableData = newValue }
+    }
+
+    func makeNSView(context: Context) -> RegionView { RegionView() }
+
+    func updateNSView(_ view: RegionView, context: Context) {
+        view.shape = shape
+        view.onHover = onHover
+    }
+
+    final class RegionView: NSView {
+        var shape = NotchShape(topRadius: 0, bottomRadius: 0)
+        var onHover: ((Bool) -> Void)?
+        override var isFlipped: Bool { true }
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            (window as? NotchWindow)?.interactionRegion = self
+        }
+
+        func contains(screenPoint: NSPoint) -> Bool {
+            guard let window else { return false }
+            let point = convert(window.convertPoint(fromScreen: screenPoint), from: nil)
+            return shape.path(in: bounds).contains(point)
+        }
+    }
+}

--- a/glance/NotchOverlay/NotchOverlayView.swift
+++ b/glance/NotchOverlay/NotchOverlayView.swift
@@ -343,6 +343,17 @@ struct NotchOverlayView: View {
         .frame(width: currentSize.width, height: currentSize.height)
         .background(Color.black)
         .clipShape(NotchShape(topRadius: topRadius, bottomRadius: bottomRadius, style: style))
+        .background {
+            NotchInteractionRegion(
+                shape: NotchShape(topRadius: topRadius, bottomRadius: bottomRadius, style: style)
+            ) { hovering in
+                isHovering = hovering
+                if hovering {
+                    performHapticFeedback(.generic)
+                    controller.activate()
+                }
+            }
+        }
         // Shadow only while expanded — with the window staying on-screen
         // continuously in armed mode, a shadow visible at the *closed* size
         // rendered as a faint dim halo sitting around the real notch even
@@ -357,17 +368,9 @@ struct NotchOverlayView: View {
         // explicit choreography above.
         .animation(expansionAnimation(entering: true), value: onboardingController?.panelSize)
         .blur(radius: panelBlur)
-        // Applied after the shadow so both travel together, and before
-        // `.onHover` so the hover region tracks where the panel actually is.
+        // Move the panel, its shadow, and its interaction region together.
         .offset(y: verticalOffset)
         .animation(.easeOut(duration: 0.18), value: isHovering)
-        .onHover { hovering in
-            isHovering = hovering
-            if hovering {
-                performHapticFeedback(.generic)
-                controller.activate()
-            }
-        }
         .onAppear {
             // Sync without animating — there's nothing to animate *from* on
             // first appearance.

--- a/glance/NotchOverlay/NotchWindow.swift
+++ b/glance/NotchOverlay/NotchWindow.swift
@@ -32,15 +32,83 @@ final class NotchWindow: NSPanel {
         level = .mainMenu + 3
         collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
 
-        // Decorative by default — clicks pass straight through. Flipped on
-        // only while a failed attempt is waiting to be tapped for retry
-        // (see NotchWindowController.setInteractive).
         ignoresMouseEvents = true
     }
 
-    /// Must be able to become key while interactive, otherwise the tap-to-
-    /// retry gesture never receives the click. Still never becomes *main*,
-    /// so it doesn't take over as the app's primary window.
-    override var canBecomeKey: Bool { !ignoresMouseEvents }
+    enum Interaction {
+        case none, hover, controls
+    }
+
+    weak var interactionRegion: NotchInteractionRegion.RegionView?
+    var interaction: Interaction = .none {
+        didSet {
+            if interaction != .controls { pressedButtons.removeAll() }
+            updatePointer()
+        }
+    }
+    private var pointerTimer: Timer?
+    private var localMonitor: Any?
+    private var globalMonitor: Any?
+    private var isHovering = false
+    private var pressedButtons: Set<Int> = []
+
+    /// Hover observation does not require the window to intercept clicks.
+    /// The timer also handles a stationary pointer while the panel animates.
+    func startPointerTracking() {
+        guard pointerTimer == nil else { return }
+        let moves: NSEvent.EventTypeMask = [.mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged]
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: moves) { [weak self] _ in
+            self?.updatePointer()
+        }
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: moves) { [weak self] event in
+            self?.updatePointer()
+            return event
+        }
+        let timer = Timer(timeInterval: 1.0 / 60, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.updatePointer() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pointerTimer = timer
+        updatePointer()
+    }
+
+    func stopPointerTracking() {
+        pointerTimer?.invalidate()
+        pointerTimer = nil
+        if let localMonitor { NSEvent.removeMonitor(localMonitor) }
+        if let globalMonitor { NSEvent.removeMonitor(globalMonitor) }
+        localMonitor = nil
+        globalMonitor = nil
+        pressedButtons.removeAll()
+        ignoresMouseEvents = true
+        setHovering(false)
+    }
+
+    func updatePointer(at screenPoint: NSPoint = NSEvent.mouseLocation) {
+        let inside = isVisible && interactionRegion?.contains(screenPoint: screenPoint) == true
+        ignoresMouseEvents = interaction != .controls || (!inside && pressedButtons.isEmpty)
+        setHovering(interaction != .none && inside)
+    }
+
+    private func setHovering(_ hovering: Bool) {
+        guard hovering != isHovering else { return }
+        isHovering = hovering
+        interactionRegion?.onHover?(hovering)
+    }
+
+    override func sendEvent(_ event: NSEvent) {
+        switch event.type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            pressedButtons.insert(event.buttonNumber)
+        case .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            pressedButtons.remove(event.buttonNumber)
+        default: break
+        }
+        super.sendEvent(event)
+        updatePointer()
+    }
+
+    // Keyboard focus must survive moving the pointer out of a password field.
+    override var canBecomeKey: Bool { interaction == .controls }
     override var canBecomeMain: Bool { false }
 }

--- a/glance/NotchOverlay/NotchWindowController.swift
+++ b/glance/NotchOverlay/NotchWindowController.swift
@@ -48,6 +48,7 @@ final class NotchWindowController {
         let window = windowIfNeeded()
         reposition(window)
         window.orderFrontRegardless()
+        window.startPointerTracking()
 
         if LockMonitor.isScreenActuallyLocked(), let skyLight = NotchSkyLight.shared {
             skyLight.delegate(window)
@@ -72,19 +73,14 @@ final class NotchWindowController {
             skyLight.undelegate(window)
             isSkyLightDelegated = false
         }
+        window.stopPointerTracking()
         window.orderOut(nil)
     }
 
-    /// Toggles whether the overlay accepts clicks. Off for the whole normal
-    /// lifecycle; on while a failed attempt waits for a retry tap, or while
-    /// onboarding is active.
-    ///
-    /// `key: true` additionally activates the app and makes the panel the
-    /// key window — needed only for onboarding's password field to receive
-    /// keystrokes. `NotchWindow.canBecomeKey` already gates on
-    /// `!ignoresMouseEvents`, so this is safe to call any time.
+    /// Hover-only states remain click-through. Onboarding accepts clicks
+    /// inside its visible shape and may also request keyboard focus.
     func setInteractive(_ interactive: Bool, key: Bool = false) {
-        window?.ignoresMouseEvents = !interactive
+        window?.interaction = !interactive ? .none : (key ? .controls : .hover)
         guard interactive, key, let window else { return }
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)

--- a/tools/README.md
+++ b/tools/README.md
@@ -63,3 +63,21 @@ python tools/convert_arcface.py --onnx-path /path/to/w600k_mbf.onnx
 If you ever swap in a different ArcFace variant (e.g. `w600k_r50` via
 `--variant w600k_r50`), this contract stays the same — only the file size
 and latency change.
+
+## Overlay input checks
+
+`notch_input_selftest.swift` opens two temporary windows and checks which one macOS would target. It covers click-through hover states, setup controls, transparent margins and rounded corners, dragging outside the popup, keyboard eligibility, and intermediate resize/slide animation frames. It does not move the mouse or require Accessibility permission.
+
+Run with Swift 6.2+ and the macOS SDK:
+
+```bash
+swiftc -swift-version 5 -default-isolation MainActor \
+  glance/NotchOverlay/NotchWindow.swift \
+  glance/NotchOverlay/NotchInteractionRegion.swift \
+  glance/NotchOverlay/NotchShape.swift \
+  glance/NotchOverlay/NotchPanelStyle.swift \
+  tools/notch_input_selftest.swift -o /tmp/glance-input-check
+/tmp/glance-input-check
+```
+
+For a manual check, move the pointer through the popup's edges and click a window behind it. During setup, also confirm that buttons and password entry work, including after moving the pointer outside the popup.

--- a/tools/notch_input_selftest.swift
+++ b/tools/notch_input_selftest.swift
@@ -1,0 +1,132 @@
+// AppKit/SwiftUI integration check; opens a small temporary window without
+// touching the camera, credentials, or Accessibility permissions.
+// Compile with NotchWindow.swift, NotchInteractionRegion.swift,
+// NotchShape.swift, and NotchPanelStyle.swift using Swift 6.2+.
+import AppKit
+import SwiftUI
+
+// These constants are only referenced by NotchShape's #Preview declarations.
+enum NotchGeometry {
+    static let pillClosedSize = CGSize(width: 140, height: 32)
+    static let pillOpenCornerRadius: CGFloat = 32
+}
+
+@MainActor @Observable private final class PanelState {
+    var width: CGFloat = 180
+    var height: CGFloat = 80
+    var offset: CGFloat = 20
+}
+
+private struct TestPanel: View {
+    let state: PanelState
+    var body: some View {
+        Color.black
+            .frame(width: state.width, height: state.height)
+            .clipShape(NotchShape(topRadius: 30, bottomRadius: 30, style: .pill))
+            .background {
+                NotchInteractionRegion(shape: NotchShape(topRadius: 30, bottomRadius: 30, style: .pill)) { _ in }
+            }
+            .offset(y: state.offset)
+            .frame(width: 434, height: 383, alignment: .top)
+    }
+}
+
+@main private struct InputCheck {
+    @MainActor static func main() {
+        _ = NSApplication.shared
+        NSApp.setActivationPolicy(.accessory)
+        let state = PanelState()
+        let underneath = NSWindow(
+            contentRect: NSRect(x: 80, y: 80, width: 434, height: 383),
+            styleMask: .borderless, backing: .buffered, defer: false
+        )
+        underneath.isReleasedWhenClosed = false
+        underneath.backgroundColor = .white
+        underneath.orderFrontRegardless()
+        defer { underneath.orderOut(nil) }
+        let panel = NotchWindow(contentRect: NSRect(x: 80, y: 80, width: 434, height: 383))
+        panel.contentView = NSHostingView(rootView: TestPanel(state: state))
+        panel.orderFrontRegardless()
+        defer { panel.stopPointerTracking(); panel.orderOut(nil) }
+        pump(0.2)
+        guard let region = panel.interactionRegion else { fatalError("No interaction region") }
+        func screen(_ point: CGPoint) -> CGPoint { panel.convertPoint(toScreen: region.convert(point, to: nil)) }
+        let inside = screen(CGPoint(x: 90, y: 40))
+        let corner = screen(CGPoint(x: 1, y: 1))
+        let outside = screen(CGPoint(x: -20, y: 40))
+        check(region.contains(screenPoint: inside), "shape center")
+        check(!region.contains(screenPoint: corner), "rounded corner excluded")
+        check(!region.contains(screenPoint: outside), "transparent margin excluded")
+        panel.interaction = .hover
+        panel.updatePointer(at: inside)
+        check(panel.ignoresMouseEvents, "hover stays click-through")
+        pump(0.03)
+        check(NSWindow.windowNumber(at: inside, belowWindowWithWindowNumber: 0) == underneath.windowNumber,
+              "WindowServer targets underlying window through hover overlay")
+        panel.interaction = .controls
+        panel.updatePointer(at: inside)
+        check(!panel.ignoresMouseEvents, "controls receive clicks inside")
+        pump(0.03)
+        check(NSWindow.windowNumber(at: inside, belowWindowWithWindowNumber: 0) == panel.windowNumber,
+              "WindowServer targets onboarding inside the shape")
+        panel.updatePointer(at: corner)
+        check(panel.ignoresMouseEvents, "rounded corner passes clicks through")
+        panel.updatePointer(at: outside)
+        check(panel.ignoresMouseEvents, "margin passes clicks through")
+        pump(0.03)
+        check(NSWindow.windowNumber(at: outside, belowWindowWithWindowNumber: 0) == underneath.windowNumber,
+              "WindowServer targets underlying window through transparent margin")
+        func mouse(_ type: NSEvent.EventType, at point: CGPoint) -> NSEvent {
+            NSEvent.mouseEvent(with: type, location: panel.convertPoint(fromScreen: point),
+                               modifierFlags: [], timestamp: ProcessInfo.processInfo.systemUptime,
+                               windowNumber: panel.windowNumber, context: nil,
+                               eventNumber: 1, clickCount: 1, pressure: type == .leftMouseDown ? 1 : 0)!
+        }
+        panel.updatePointer(at: inside)
+        panel.sendEvent(mouse(.leftMouseDown, at: inside))
+        panel.updatePointer(at: outside)
+        check(!panel.ignoresMouseEvents, "drag retains capture outside the popup")
+        panel.sendEvent(mouse(.leftMouseUp, at: outside))
+        panel.updatePointer(at: outside)
+        check(panel.ignoresMouseEvents, "release restores outside click-through")
+        panel.sendEvent(mouse(.leftMouseDown, at: inside))
+        panel.interaction = .hover
+        panel.interaction = .controls
+        panel.updatePointer(at: outside)
+        check(panel.ignoresMouseEvents, "mode change clears stale drag capture")
+        check(panel.canBecomeKey, "keyboard eligibility survives pointer exit")
+        panel.interaction = .none
+        panel.updatePointer(at: inside)
+        check(panel.ignoresMouseEvents, "decorative state passes clicks through")
+
+        withAnimation(.linear(duration: 0.5)) {
+            state.width = 320
+            state.height = 160
+            state.offset = 80
+        }
+        var widths: [CGFloat] = []
+        var positions: [CGFloat] = []
+        for _ in 0..<35 {
+            pump(0.02)
+            widths.append(region.bounds.width)
+            positions.append(region.convert(.zero, to: nil).y)
+        }
+        check(widths.contains { $0 > 185 && $0 < 315 }, "region follows intermediate resize frames")
+        check(positions.max()! - positions.min()! > 30, "region follows slide")
+        check(abs(region.bounds.width - 320) < 1, "region reaches final width")
+        panel.orderOut(nil)
+        panel.interaction = .controls
+        panel.updatePointer(at: inside)
+        check(panel.ignoresMouseEvents, "hidden window ignores clicks")
+        print("PASS: all overlay input checks")
+    }
+
+    @MainActor private static func pump(_ seconds: TimeInterval) {
+        RunLoop.main.run(until: Date().addingTimeInterval(seconds))
+    }
+    private static func check(_ condition: Bool, _ message: String) {
+        guard condition else { fatalError("FAIL: \(message)") }
+        print("PASS: \(message)")
+        fflush(stdout)
+    }
+}


### PR DESCRIPTION
The overlay uses a fixed window large enough for onboarding and expansion animations. Enabling mouse events for hover or setup also lets its invisible margins intercept clicks meant for the window underneath.

Keep scan/retry states click-through and observe the pointer separately. During onboarding, accept clicks only inside the visible animated shape, including its rounded corners. Preserve mouse capture through a drag, clear it when interaction modes change, and keep keyboard eligibility independent of pointer position.

Validation: the standalone AppKit/SwiftUI integration test passes on macOS 15.7.4. It checks WindowServer targeting, transparent margins, rounded corners, drag/release behavior, mode changes, keyboard eligibility, and intermediate resize/slide frames. The installed fix was also manually tested and confirmed to resolve the click interception. Test instructions are in `tools/README.md`.
