### PR TITLE
Add Face-for-sudo (Face → Touch ID → password)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ xcuserdata/
 # Compiled Core ML models are derived from the committed .mlpackage source
 *.mlmodelc
 
+# Built PAM module (Xcode embed phase / make — never commit the binary)
+pam_glance/pam_glance.so
+
 # Python virtualenv used by tools/convert_arcface.py
 .venv/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ https://github.com/user-attachments/assets/77438826-80a9-4ab2-9fc3-42407a2d0adb
 > 
 > Glance is a convenience feature, not a security upgrade. It's off by default, and you can leave
 it that way.
+>
+> **Face for sudo** (optional): when enabled, `sudo` can try Glance face match first, then Touch ID, then password. It only works while Glance is running with an unlocked session — same 2D-camera limits as lock-screen unlock. See `pam_glance/README.md`.
 
 ## Installation
 
@@ -159,6 +161,9 @@ debug section should appear in the sidebar.
   ```
 3. Run the project:
   - Click `run` or press `Cmd + R`.
+  - The **Embed pam_glance** build phase compiles the Face-for-sudo PAM module into the app automatically.
+
+Face for sudo (optional): unlock the session → Settings → General → **Face for sudo**. Details in [`pam_glance/README.md`](pam_glance/README.md).
 
 
 

--- a/glance.xcodeproj/project.pbxproj
+++ b/glance.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 				601C4938300FFC8400D3DE9D /* Sources */,
 				601C4939300FFC8400D3DE9D /* Frameworks */,
 				601C493A300FFC8400D3DE9D /* Resources */,
+				B7E4A91C2F5A4D0E9C1D2E3F /* Embed pam_glance */,
 			);
 			buildRules = (
 			);
@@ -135,6 +136,34 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B7E4A91C2F5A4D0E9C1D2E3F /* Embed pam_glance */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/pam_glance/pam_glance.c",
+				"$(SRCROOT)/pam_glance/install.sh",
+				"$(SRCROOT)/pam_glance/Makefile",
+				"$(SRCROOT)/pam_glance/embed-resources.sh",
+			);
+			name = "Embed pam_glance";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/pam_glance.so",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/pam_glance_install.sh",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\"${SRCROOT}/pam_glance/embed-resources.sh\" \"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		601C4938300FFC8400D3DE9D /* Sources */ = {

--- a/glance/AppEnvironment.swift
+++ b/glance/AppEnvironment.swift
@@ -22,6 +22,8 @@ final class AppEnvironment {
     /// timer — letting it deallocate would silently stop enforcing the
     /// auto-lock interval.
     let sessionAutoLocker: SessionAutoLocker
+    /// Face-for-sudo socket server + PAM install orchestration.
+    let sudoAuthController = SudoAuthController()
     /// Sparkle auto-update controller — see `Updater/UpdaterController.swift`
     /// and RELEASING.md. Constructed here (not started) so the About page
     /// and `AppDelegate` share the exact same instance; `AppDelegate.

--- a/glance/KeychainManager.swift
+++ b/glance/KeychainManager.swift
@@ -38,6 +38,14 @@ enum KeychainError: LocalizedError {
 enum KeychainManager {
     nonisolated static let service = "com.jonathan.glance"
 
+    /// `errSecMissingEntitlement` (-34018) — common on local/ad-hoc builds
+    /// when ACL-gated Keychain items need entitlements the binary doesn't have.
+    nonisolated private static let missingEntitlementStatus: OSStatus = -34018
+
+    nonisolated private static func isMissingEntitlement(_ status: OSStatus) -> Bool {
+        status == missingEntitlementStatus || status == errSecMissingEntitlement
+    }
+
     /// Attributes-only existence check — never prompts, even for access-controlled items.
     nonisolated static func exists(account: String) -> Bool {
         let query: [String: Any] = [
@@ -66,7 +74,13 @@ enum KeychainManager {
             query[kSecUseAuthenticationContext as String] = context
         }
         var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        var status = SecItemCopyMatching(query as CFDictionary, &item)
+        // Non-ACL items (or entitlement-starved builds) may reject LAContext.
+        if isMissingEntitlement(status), context != nil {
+            query.removeValue(forKey: kSecUseAuthenticationContext as String)
+            item = nil
+            status = SecItemCopyMatching(query as CFDictionary, &item)
+        }
         switch status {
         case errSecSuccess:
             guard let data = item as? Data else { throw KeychainError.unexpectedData }
@@ -104,7 +118,14 @@ enum KeychainManager {
             addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         }
 
-        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        var status = SecItemAdd(addQuery as CFDictionary, nil)
+        // Local Xcode / wrong-team / ad-hoc builds often can't create ACL items.
+        if accessControl != nil, status != errSecSuccess {
+            SecItemDelete(deleteQuery as CFDictionary)
+            addQuery.removeValue(forKey: kSecAttrAccessControl as String)
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
         guard status == errSecSuccess else { throw KeychainError.osStatus(status) }
     }
 

--- a/glance/SecureCredentialManager.swift
+++ b/glance/SecureCredentialManager.swift
@@ -207,21 +207,21 @@ enum SecureCredentialManager {
         }
 
         let key = SymmetricKey(size: .bits256)
-        let access = try KeychainManager.makeUserPresenceAccessControl()
-        try KeychainManager.save(
-            account: sessionKeyAccount,
-            data: key.withUnsafeBytes { Data($0) },
-            accessControl: access
-        )
+        let keyData = key.withUnsafeBytes { Data($0) }
+        // ACL when the build allows it; KeychainManager.save falls back to a
+        // non-biometric item if entitlements/signing block AccessControl.
+        let access = try? KeychainManager.makeUserPresenceAccessControl()
+        try KeychainManager.save(account: sessionKeyAccount, data: keyData, accessControl: access)
 
-        // Read back through the same gated path rather than trusting the
-        // write: `SecItemAdd` returns success regardless of how any auth UI
-        // macOS showed around it resolved, so only a real read proves the
-        // user actually authenticated.
         let readBackContext = LAContext()
         readBackContext.localizedReason = reason
-        let data = try KeychainManager.read(account: sessionKeyAccount, context: readBackContext)
-        setCachedKey(SymmetricKey(data: data))
+        do {
+            let data = try KeychainManager.read(account: sessionKeyAccount, context: readBackContext)
+            setCachedKey(SymmetricKey(data: data))
+        } catch {
+            // Non-ACL store or LA read blocked — we still hold the key we wrote.
+            setCachedKey(key)
+        }
     }
 
     /// Whether anything on this Mac is currently encrypted under the session

--- a/glance/Settings/GlanceSettings.swift
+++ b/glance/Settings/GlanceSettings.swift
@@ -128,6 +128,7 @@ final class GlanceSettings {
         static let externalDisplayCameraID = "GlanceSettings.externalDisplayCameraID"
         static let hasCompletedOnboarding = "GlanceSettings.hasCompletedOnboarding"
         static let onboardingResumeStep = "GlanceSettings.onboardingResumeStep"
+        static let isSudoFaceEnabled = "GlanceSettings.isSudoFaceEnabled"
     }
 
     @ObservationIgnored private let defaults = UserDefaults.standard
@@ -297,6 +298,12 @@ final class GlanceSettings {
     var onboardingResumeStep: OnboardingStep? {
         didSet { defaults.set(onboardingResumeStep?.rawValue, forKey: Key.onboardingResumeStep) }
     }
+    /// Opt-in Face auth for Terminal `sudo` (PAM). Requires a built
+    /// `pam_glance.so`, an unlocked Glance session, and install into
+    /// `/etc/pam.d/sudo_local`. Off by default.
+    var isSudoFaceEnabled: Bool {
+        didSet { defaults.set(isSudoFaceEnabled, forKey: Key.isSudoFaceEnabled) }
+    }
 
     private init() {
         // Enabled out of the box — a fresh install has just finished
@@ -318,7 +325,7 @@ final class GlanceSettings {
             .flatMap(LivenessMode.init(rawValue:)) ?? .light
         // Matches `DetectionDistanceLevel.standard` ("Default" on the
         // Recognition page) — see RecognitionSettingsPage.swift.
-        minimumFaceWidth = defaults.object(forKey: Key.minimumFaceWidth) as? Float ?? 0.21
+        minimumFaceWidth = defaults.object(forKey: Key.minimumFaceWidth) as? Float ?? 0.18
 
         // Resolve the stored style first, `.none` included, then split it
         // into the pick + the on/off flag the UI now works in.
@@ -376,6 +383,7 @@ final class GlanceSettings {
         hasCompletedOnboarding = defaults.object(forKey: Key.hasCompletedOnboarding) as? Bool ?? false
         onboardingResumeStep = defaults.string(forKey: Key.onboardingResumeStep)
             .flatMap(OnboardingStep.init(rawValue:))
+        isSudoFaceEnabled = defaults.object(forKey: Key.isSudoFaceEnabled) as? Bool ?? false
 
         // Push the persisted value into the nonisolated mirror immediately —
         // otherwise FaceRecognitionPipeline would keep using its own 0.18

--- a/glance/Settings/Pages/GeneralSettingsPage.swift
+++ b/glance/Settings/Pages/GeneralSettingsPage.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct GeneralSettingsPage: View {
     @Bindable var coordinator: FaceUnlockCoordinator
+    @Bindable var sudoAuth: SudoAuthController
     @Bindable private var settings = GlanceSettings.shared
 
     @State private var launchAtLoginEnabled = LaunchAtLogin.isEnabled
@@ -60,9 +61,20 @@ struct GeneralSettingsPage: View {
                 GlanceToggle(isOn: $coordinator.isEnabled)
             }
             SettingsGroupDivider()
+            SettingsRowContent(title: "Face for sudo") {
+                GlanceToggle(isOn: Binding(
+                    get: { sudoAuth.isSudoFaceEnabled },
+                    set: { sudoAuth.isSudoFaceEnabled = $0 }
+                ))
+            }
+            SettingsGroupDivider()
             UnlockTriggerPicker(selection: $settings.unlockTriggers, isEnabled: coordinator.isEnabled)
             SettingsGroupDivider()
             displayPicker()
+        }
+        .onAppear {
+            sudoAuth.refreshInstallStatus()
+            sudoAuth.reconcileListener()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)) { _ in
             screens = NSScreen.screens
@@ -88,6 +100,17 @@ struct GeneralSettingsPage: View {
         }
         if let launchAtLoginError {
             SettingsCaption(text: launchAtLoginError)
+        }
+        if let installError = sudoAuth.lastInstallError {
+            SettingsCaption(text: installError)
+        } else if sudoAuth.isSudoFaceEnabled {
+            let status = sudoAuth.pamInstallStatus.label
+            let listener = sudoAuth.isListenerActive
+                ? "Listening for sudo."
+                : (SecureCredentialManager.isSessionUnlocked
+                   ? "Waiting for PAM install."
+                   : "Unlock session for Face sudo.")
+            SettingsCaption(text: "\(status) — \(listener) Cascade: Face → Touch ID → password.")
         }
         if hasInheritedXcodePermission {
             SettingsCaption(text: "Running from Xcode — permission checks resolve against Xcode’s grants, not glance’s, so this reading is meaningless. Launch glance.app on its own to see the real state.")

--- a/glance/Settings/Pages/PasswordSettingsPage.swift
+++ b/glance/Settings/Pages/PasswordSettingsPage.swift
@@ -12,6 +12,9 @@ struct PasswordSettingsPage: View {
     @State private var isUnlocking = false
     @State private var sessionError: String?
     @State private var statusMessage: String?
+    /// Set after a successful orphan wipe so the UI leaves `.orphanedKey`
+    /// even if Observation misses a non-@Observable Keychain/file check.
+    @State private var didClearOrphan = false
 
     /// Read from `POCController` rather than a local `@State` copy: the
     /// session can also be locked from outside this view (by
@@ -29,23 +32,38 @@ struct PasswordSettingsPage: View {
     /// wrong with nothing stored to encrypt or remove.
     private enum PageState: Equatable {
         case noPassword
+        /// Session key Keychain item is gone but password/face ciphertext remain
+        /// — unlock can never succeed; must wipe and re-enroll.
+        case orphanedKey
         case locked
         case unlocked
     }
 
     private var pageState: PageState {
-        guard pocController.hasStoredPassword else { return .noPassword }
-        return isSessionUnlocked ? .unlocked : .locked
+        if didClearOrphan { return .noPassword }
+        guard pocController.hasStoredPassword || SecureCredentialManager.hasSessionEncryptedData else {
+            return .noPassword
+        }
+        if isSessionUnlocked { return .unlocked }
+        // Key missing while ciphertext remains → Unlock will never prompt usefully.
+        if SecureCredentialManager.hasSessionEncryptedData,
+           !KeychainManager.exists(account: "sessionKey") {
+            return .orphanedKey
+        }
+        return .locked
     }
 
     var body: some View {
         ZStack(alignment: .top) {
             noPasswordState
                 .opacity(pageState == .noPassword ? 1 : 0)
-                // Hidden from hit-testing *and* accessibility while faded
-                // out, so an invisible copy can't be clicked or focused.
                 .allowsHitTesting(pageState == .noPassword)
                 .accessibilityHidden(pageState != .noPassword)
+
+            orphanedKeyState
+                .opacity(pageState == .orphanedKey ? 1 : 0)
+                .allowsHitTesting(pageState == .orphanedKey)
+                .accessibilityHidden(pageState != .orphanedKey)
 
             lockedState
                 .opacity(pageState == .locked ? 1 : 0)
@@ -59,14 +77,6 @@ struct PasswordSettingsPage: View {
         }
         .animation(SettingsMetrics.stateTransitionAnimation, value: pageState)
         .onAppear { pocController.refreshCredentialStatus() }
-        // The onboarding password step runs in the notch, entirely outside
-        // this window's view hierarchy — this view never disappears while
-        // it's open, so nothing would otherwise prompt a re-check once it
-        // closes. Without this, setting a password via "Set password" (or
-        // changing one via "Change") would leave this page showing stale
-        // state until the user happened to switch tabs and back. `.closed`
-        // also fires after unrelated face-unlock scan cycles; re-running a
-        // cheap, side-effect-free status read then is harmless.
         .onChange(of: NotchOverlayController.shared.phase) { _, newPhase in
             guard newPhase == .closed else { return }
             pocController.refreshCredentialStatus()
@@ -83,6 +93,19 @@ struct PasswordSettingsPage: View {
             buttonTitle: "Set password",
             caption: statusMessage,
             action: { OnboardingController.startPasswordOnly() }
+        )
+    }
+
+    // MARK: - Orphaned key (can't unlock — no Touch ID prompt path)
+
+    private var orphanedKeyState: some View {
+        SettingsEmptyStateView(
+            icon: "exclamationmark.triangle.fill",
+            message: "Session key missing",
+            buttonTitle: "Clear and start fresh",
+            caption: sessionError
+                ?? "Encrypted data is still on disk but the Touch ID key is gone (common after switching builds). Clear password + faces, then set up again. No Mac login password is asked here.",
+            action: clearOrphanedCredentials
         )
     }
 
@@ -176,6 +199,31 @@ struct PasswordSettingsPage: View {
             statusMessage = "Password and face enrollment removed."
         } catch {
             statusMessage = "Couldn't remove: \(error.localizedDescription)"
+        }
+    }
+
+    /// Wipe without unlocking — used when the session key item is gone and
+    /// Touch ID can never unwrap it.
+    private func clearOrphanedCredentials() {
+        sessionError = "Clearing…"
+        FaceEnrollmentStore.shared.deleteAll()
+        SecureFaceStore.deleteAll()
+        try? KeychainManager.delete(account: "encryptedPassword")
+        try? KeychainManager.delete(account: "sessionKey")
+        try? SecureCredentialManager.deletePassword()
+        SecureCredentialManager.lockSession()
+        pocController.refreshCredentialStatus()
+        pocController.sessionError = nil
+
+        let stillStuck = SecureCredentialManager.hasSessionEncryptedData
+            || pocController.hasStoredPassword
+        if stillStuck {
+            sessionError = "Still couldn’t clear Keychain items. Quit Glance and run: security delete-generic-password -s com.jonathan.glance"
+            didClearOrphan = false
+        } else {
+            didClearOrphan = true
+            sessionError = nil
+            statusMessage = "Cleared. Tap Set password to start fresh."
         }
     }
 }

--- a/glance/Settings/Pages/RecognitionSettingsPage.swift
+++ b/glance/Settings/Pages/RecognitionSettingsPage.swift
@@ -195,9 +195,12 @@ private enum DetectionDistanceLevel: Int, CaseIterable {
 
     var minimumFaceWidth: Float {
         switch self {
+        // Normalized face width in the frame. Smaller = works farther away.
+        // Roughly: ~0.24 ≈ 20–25cm, ~0.18 ≈ 30–35cm, ~0.09 ≈ 50–60cm
+        // on a typical MacBook webcam.
         case .close: return 0.24
-        case .standard: return 0.2
-        case .far: return 0.17
+        case .standard: return 0.18
+        case .far: return 0.09
         }
     }
 

--- a/glance/Settings/SettingsWindowView.swift
+++ b/glance/Settings/SettingsWindowView.swift
@@ -221,7 +221,10 @@ struct SettingsWindowView: View {
         VStack(alignment: .leading, spacing: SettingsMetrics.rowSpacing) {
             switch selection {
             case .general:
-                GeneralSettingsPage(coordinator: environment.faceUnlockCoordinator)
+                GeneralSettingsPage(
+                    coordinator: environment.faceUnlockCoordinator,
+                    sudoAuth: environment.sudoAuthController
+                )
             case .yourFace:
                 YourFaceSettingsPage(environment: environment)
             case .password:

--- a/glance/SudoAuth/SudoAuthController.swift
+++ b/glance/SudoAuth/SudoAuthController.swift
@@ -1,0 +1,106 @@
+//
+//  SudoAuthController.swift
+//  glance
+//
+//  Owns the sudo face-auth socket server and keeps it in sync with session
+//  lock state + the Settings toggle.
+//
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class SudoAuthController {
+    private let server = SudoAuthServer()
+    private var sessionObserver: NSObjectProtocol?
+
+    private(set) var isListenerActive = false
+    private(set) var pamInstallStatus: SudoAuthInstaller.Status = .unknown
+    private(set) var lastInstallError: String?
+
+    var isSudoFaceEnabled: Bool {
+        get { GlanceSettings.shared.isSudoFaceEnabled }
+        set {
+            GlanceSettings.shared.isSudoFaceEnabled = newValue
+            Task { await applyPreferenceChange(enabled: newValue) }
+        }
+    }
+
+    init() {
+        sessionObserver = NotificationCenter.default.addObserver(
+            forName: .secureCredentialSessionDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshInstallStatus()
+                self?.reconcileListener()
+            }
+        }
+        refreshInstallStatus()
+        reconcileListener()
+    }
+
+    func refreshInstallStatus() {
+        pamInstallStatus = SudoAuthInstaller.currentStatus()
+    }
+
+    func reconcileListener() {
+        refreshInstallStatus()
+        let unlocked = SecureCredentialManager.isSessionUnlocked
+        let enabled = GlanceSettings.shared.isSudoFaceEnabled
+        let pamOK = pamInstallStatus.isOperational
+        let shouldListen = enabled && unlocked && pamOK
+        if shouldListen {
+            server.startIfNeeded()
+        } else {
+            server.stop()
+        }
+        isListenerActive = server.isListening
+        if enabled && pamOK && !unlocked {
+            lastInstallError = "Unlock session (menu bar → Session Locked) — Face for sudo needs an unlocked session."
+        } else if enabled && isListenerActive {
+            lastInstallError = nil
+        }
+    }
+
+    private func applyPreferenceChange(enabled: Bool) async {
+        lastInstallError = nil
+        if enabled {
+            refreshInstallStatus()
+            // Already on disk + in sudo_local — skip privileged install (osascript
+            // can't write /etc/pam.d and was flipping the toggle off).
+            if pamInstallStatus.isOperational {
+                reconcileListener()
+                if !SecureCredentialManager.isSessionUnlocked {
+                    lastInstallError = "Unlock session (menu bar) so Face for sudo can listen."
+                }
+                return
+            }
+            do {
+                try await SudoAuthInstaller.install()
+                refreshInstallStatus()
+                reconcileListener()
+                if !SecureCredentialManager.isSessionUnlocked {
+                    lastInstallError = "Unlock session (menu bar) so Face for sudo can listen."
+                }
+            } catch {
+                refreshInstallStatus()
+                if pamInstallStatus.isOperational {
+                    lastInstallError = "Install helper failed, but PAM is already set up. Unlock session to listen."
+                    reconcileListener()
+                } else {
+                    GlanceSettings.shared.isSudoFaceEnabled = false
+                    lastInstallError = error.localizedDescription
+                    reconcileListener()
+                }
+            }
+        } else {
+            // Stop listening only — leave PAM installed (avoids blocked /etc write).
+            lastInstallError = nil
+            refreshInstallStatus()
+            reconcileListener()
+        }
+    }
+}

--- a/glance/SudoAuth/SudoAuthInstaller.swift
+++ b/glance/SudoAuth/SudoAuthInstaller.swift
@@ -1,0 +1,155 @@
+//
+//  SudoAuthInstaller.swift
+//  glance
+//
+//  Installs pam_glance.so and ensures /etc/pam.d/sudo_local lists it above
+//  pam_tid.so via pam_glance_install.sh + osascript admin privileges.
+//
+
+import Foundation
+
+enum SudoAuthInstaller {
+    static let moduleInstallPath = "/usr/local/lib/pam/pam_glance.so"
+    static let sudoLocalPath = "/etc/pam.d/sudo_local"
+
+    enum Status: Equatable {
+        case unknown
+        case missingModule
+        case missingPamLine
+        case installed
+        case error(String)
+
+        var isOperational: Bool { self == .installed }
+
+        var label: String {
+            switch self {
+            case .unknown: return "Checking…"
+            case .missingModule: return "PAM module missing from this build"
+            case .missingPamLine: return "Not installed into sudo yet"
+            case .installed: return "Installed"
+            case .error(let message): return message
+            }
+        }
+    }
+
+    enum InstallError: LocalizedError {
+        case moduleMissingFromBundle
+        case scriptMissingFromBundle
+        case privilegedCommandFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .moduleMissingFromBundle:
+                return "pam_glance.so is missing from this app build. Rebuild Glance so the Embed pam_glance phase can produce it."
+            case .scriptMissingFromBundle:
+                return "pam_glance install script missing from this app build."
+            case .privilegedCommandFailed(let detail):
+                return detail
+            }
+        }
+    }
+
+    static func currentStatus() -> Status {
+        let moduleOK = FileManager.default.isReadableFile(atPath: moduleInstallPath)
+        let bundledOK = bundledModuleURL().map { FileManager.default.isReadableFile(atPath: $0.path) } ?? false
+        if !moduleOK && !bundledOK {
+            return .missingModule
+        }
+        if !moduleOK {
+            return .missingPamLine
+        }
+
+        // /etc/pam.d is often unreadable without Full Disk Access. If we
+        // can't read it but the .so is already installed system-wide, treat
+        // as installed so the socket listener can start (sudo_local was
+        // verified at install time).
+        guard let contents = try? String(contentsOfFile: sudoLocalPath, encoding: .utf8) else {
+            return .installed
+        }
+        let hasGlance = contents.split(separator: "\n").contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return !trimmed.hasPrefix("#") && trimmed.contains("pam_glance.so")
+        }
+        return hasGlance ? .installed : .missingPamLine
+    }
+
+    static func bundledModuleURL() -> URL? {
+        Bundle.main.url(forResource: "pam_glance", withExtension: "so")
+    }
+
+    static func bundledInstallScriptURL() -> URL? {
+        Bundle.main.url(forResource: "pam_glance_install", withExtension: "sh")
+    }
+
+    @MainActor
+    static func install() async throws {
+        guard let moduleURL = bundledModuleURL(),
+              FileManager.default.isReadableFile(atPath: moduleURL.path) else {
+            throw InstallError.moduleMissingFromBundle
+        }
+        guard let scriptURL = bundledInstallScriptURL(),
+              FileManager.default.isReadableFile(atPath: scriptURL.path) else {
+            throw InstallError.scriptMissingFromBundle
+        }
+
+        // Copy script to a root-readable temp path — app bundle paths can
+        // contain spaces and the script must be executable by the admin shell.
+        let tmpScript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pam_glance_install.sh")
+        try? FileManager.default.removeItem(at: tmpScript)
+        try FileManager.default.copyItem(at: scriptURL, to: tmpScript)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmpScript.path
+        )
+
+        let cmd = "\(shellEscape(tmpScript.path)) install \(shellEscape(moduleURL.path))"
+        try runAdminShell(cmd)
+    }
+
+    @MainActor
+    static func uninstallModuleLine() async throws {
+        guard let scriptURL = bundledInstallScriptURL(),
+              FileManager.default.isReadableFile(atPath: scriptURL.path) else {
+            // Nothing to uninstall if the script was never bundled.
+            return
+        }
+        let tmpScript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pam_glance_install.sh")
+        try? FileManager.default.removeItem(at: tmpScript)
+        try FileManager.default.copyItem(at: scriptURL, to: tmpScript)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmpScript.path
+        )
+        let cmd = "\(shellEscape(tmpScript.path)) uninstall"
+        try runAdminShell(cmd)
+    }
+
+    private static func shellEscape(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func runAdminShell(_ command: String) throws {
+        let encoded = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let appleScript = "do shell script \"\(encoded)\" with administrator privileges"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", appleScript]
+        let errPipe = Pipe()
+        process.standardError = errPipe
+        process.standardOutput = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: errData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw InstallError.privilegedCommandFailed(
+                message?.isEmpty == false ? message! : "Administrator authorization failed."
+            )
+        }
+    }
+}

--- a/glance/SudoAuth/SudoAuthProtocol.swift
+++ b/glance/SudoAuth/SudoAuthProtocol.swift
@@ -1,0 +1,38 @@
+//
+//  SudoAuthProtocol.swift
+//  glance
+//
+//  Shared constants for the Face-for-sudo IPC path. The PAM module
+//  (pam_glance.so) connects as root to a Unix-domain socket owned by the
+//  logged-in user; the Glance app listens only while its Touch ID session
+//  is unlocked. Keep the path format and response tokens in sync with
+//  pam_glance/pam_glance.c.
+//
+
+import Foundation
+
+enum SudoAuthProtocol {
+    static let serviceName = "com.jonathan.glance.sudoauth"
+
+    /// Default scan window when the PAM client does not send a timeout.
+    static let defaultTimeoutSeconds: UInt32 = 8
+
+    /// Absolute max the server will honor (guards a malicious / buggy client).
+    static let maxTimeoutSeconds: UInt32 = 20
+
+    enum Result: String {
+        case allow = "ALLOW"
+        case deny = "DENY"
+        case unavailable = "UNAVAIL"
+    }
+
+    /// Socket path for the given user id — PAM resolves the uid of the
+    /// account being authenticated and connects here.
+    static func socketPath(uid: uid_t) -> String {
+        "/tmp/\(serviceName).\(uid)"
+    }
+
+    static var currentUserSocketPath: String {
+        socketPath(uid: getuid())
+    }
+}

--- a/glance/SudoAuth/SudoAuthServer.swift
+++ b/glance/SudoAuth/SudoAuthServer.swift
@@ -1,0 +1,144 @@
+//
+//  SudoAuthServer.swift
+//  glance
+//
+//  Unix-domain socket listener for pam_glance.so. Accepts one auth at a
+//  time; concurrent connections get UNAVAIL so PAM falls through to Touch ID.
+//
+
+import Foundation
+
+@MainActor
+final class SudoAuthServer {
+    private var listenFD: Int32 = -1
+    private var acceptSource: DispatchSourceRead?
+    private var isBusy = false
+    private var authTask: Task<Void, Never>?
+    private let runner = SudoFaceAuthRunner()
+
+    private(set) var isListening = false
+
+    func startIfNeeded() {
+        guard !isListening else { return }
+        guard SecureCredentialManager.isSessionUnlocked else { return }
+        guard GlanceSettings.shared.isSudoFaceEnabled else { return }
+
+        let path = SudoAuthProtocol.currentUserSocketPath
+        unlink(path)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { cPath in
+            withUnsafeMutableBytes(of: &addr.sun_path) { buf in
+                let count = min(strlen(cPath) + 1, buf.count)
+                _ = memcpy(buf.baseAddress, cPath, count)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let err = errno
+            NSLog("SudoAuthServer: bind(%@) failed errno=%d", path, err)
+            close(fd)
+            return
+        }
+
+        // Root (sudo/PAM) must be able to connect; owner-only would block it.
+        chmod(path, 0o666)
+
+        guard listen(fd, 2) == 0 else {
+            close(fd)
+            unlink(path)
+            return
+        }
+
+        listenFD = fd
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .main)
+        source.setEventHandler { [weak self] in
+            self?.acceptConnection()
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        acceptSource = source
+        isListening = true
+    }
+
+    func stop() {
+        authTask?.cancel()
+        authTask = nil
+        isBusy = false
+        acceptSource?.cancel()
+        acceptSource = nil
+        listenFD = -1
+        unlink(SudoAuthProtocol.currentUserSocketPath)
+        isListening = false
+    }
+
+    private func acceptConnection() {
+        guard listenFD >= 0 else { return }
+        let client = accept(listenFD, nil, nil)
+        guard client >= 0 else { return }
+
+        if isBusy || !SecureCredentialManager.isSessionUnlocked || !GlanceSettings.shared.isSudoFaceEnabled {
+            writeResult(.unavailable, to: client)
+            close(client)
+            return
+        }
+
+        isBusy = true
+        authTask = Task { @MainActor [weak self] in
+            guard let self else {
+                Self.writeResultStatic(.unavailable, to: client)
+                close(client)
+                return
+            }
+            let timeout = self.readTimeout(from: client)
+            let result = await self.runner.authenticate(timeout: TimeInterval(timeout))
+            if Task.isCancelled {
+                Self.writeResultStatic(.deny, to: client)
+            } else {
+                self.writeResult(result, to: client)
+            }
+            close(client)
+            self.isBusy = false
+            self.authTask = nil
+        }
+    }
+
+    /// Protocol: optional `"AUTH <seconds>\n"`; empty/unknown → default timeout.
+    private func readTimeout(from fd: Int32) -> UInt32 {
+        var buffer = [UInt8](repeating: 0, count: 64)
+        usleep(150_000)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { return SudoAuthProtocol.defaultTimeoutSeconds }
+        let line = String(bytes: buffer.prefix(Int(n)), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if line.hasPrefix("AUTH") {
+            let parts = line.split(separator: " ")
+            if parts.count >= 2, let value = UInt32(parts[1]) {
+                return min(max(value, 1), SudoAuthProtocol.maxTimeoutSeconds)
+            }
+        }
+        return SudoAuthProtocol.defaultTimeoutSeconds
+    }
+
+    private func writeResult(_ result: SudoAuthProtocol.Result, to fd: Int32) {
+        Self.writeResultStatic(result, to: fd)
+    }
+
+    private static func writeResultStatic(_ result: SudoAuthProtocol.Result, to fd: Int32) {
+        let payload = result.rawValue + "\n"
+        payload.withCString { ptr in
+            _ = write(fd, ptr, strlen(ptr))
+        }
+    }
+}

--- a/glance/SudoAuth/SudoFaceAuthRunner.swift
+++ b/glance/SudoAuth/SudoFaceAuthRunner.swift
@@ -1,0 +1,143 @@
+//
+//  SudoFaceAuthRunner.swift
+//  glance
+//
+//  One-shot face match for sudo: camera + ArcFace + optional liveness.
+//  Shows the notch/pill scan animation so sudo auth isn't invisible —
+//  does not type passwords.
+//
+
+import Foundation
+
+@MainActor
+final class SudoFaceAuthRunner {
+    private let camera = CameraManager()
+    private let pipeline = FaceRecognitionPipeline()
+    private let wrongFaceStreakThreshold = 6
+
+    /// Runs until match+liveness, consistent wrong face, timeout, or cancel.
+    func authenticate(timeout: TimeInterval) async -> SudoAuthProtocol.Result {
+        guard SecureCredentialManager.isSessionUnlocked else {
+            return .unavailable
+        }
+        FaceEnrollmentStore.shared.reloadIfUnlocked()
+        let identities = FaceEnrollmentStore.shared.activeIdentities
+        guard !identities.isEmpty else {
+            return .unavailable
+        }
+
+        let showsUI = GlanceSettings.shared.showUnlockAnimation
+        if showsUI {
+            NotchOverlayController.shared.present()
+            try? await Task.sleep(nanoseconds: 150_000_000)
+        }
+        var authResult: SudoAuthProtocol.Result = .deny
+        defer {
+            if showsUI {
+                NotchOverlayController.shared.finish(success: authResult == .allow)
+            }
+        }
+
+        await camera.start()
+        defer { camera.stop() }
+
+        guard camera.permission == .granted else {
+            authResult = .unavailable
+            return authResult
+        }
+
+        let warmupDeadline = Date().addingTimeInterval(1.5)
+        while Date() < warmupDeadline, camera.currentFrame == nil {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            if Task.isCancelled {
+                authResult = .deny
+                return authResult
+            }
+        }
+
+        let settings = GlanceSettings.shared
+        let matchThreshold = settings.matchThreshold
+        let livenessEnabled = settings.livenessChecksEnabled
+        let livenessMode = settings.livenessMode
+        let liveness = LivenessAnalyzer()
+        liveness.modeProvider = { livenessMode }
+        let deadline = Date().addingTimeInterval(timeout)
+
+        var consecutiveWrongFaceFrames = 0
+        var readyMatch: ScoredIdentity?
+        var livenessConfirmed = !livenessEnabled
+        var lastFaceBoundingBox: CGRect?
+        var lastProcessedFrameID: UInt64?
+
+        while Date() < deadline {
+            if Task.isCancelled {
+                authResult = .deny
+                return authResult
+            }
+            guard SecureCredentialManager.isSessionUnlocked else {
+                authResult = .unavailable
+                return authResult
+            }
+
+            guard let frame = camera.currentFrame, frame.id != lastProcessedFrameID else {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                continue
+            }
+            lastProcessedFrameID = frame.id
+
+            let pipeline = self.pipeline
+            let previousBoundingBox = lastFaceBoundingBox
+            let outcome = await Task.detached(priority: .userInitiated) { () -> (FaceRecognitionResult, LivenessFrame)? in
+                guard let result = try? pipeline.recognize(in: frame.image, preferNear: previousBoundingBox) else {
+                    return nil
+                }
+                let faceCrop = CameraManager.renderCrop(from: frame, imageRect: result.face.boundingBox)
+                return (result, LivenessFeatureExtractor.extract(from: result, frame: frame.image, faceCrop: faceCrop))
+            }.value
+
+            guard let (result, livenessFrame) = outcome else {
+                consecutiveWrongFaceFrames = 0
+                lastFaceBoundingBox = nil
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                continue
+            }
+            lastFaceBoundingBox = result.face.normalizedBoundingBox
+
+            if livenessEnabled {
+                let snapshot = liveness.observe(livenessFrame)
+                switch snapshot.decision {
+                case .denied:
+                    authResult = .deny
+                    return authResult
+                case .confirmed:
+                    livenessConfirmed = true
+                case .pending:
+                    break
+                }
+            }
+
+            let scored = pipeline.score(result.embedding, against: identities)
+            if let matched = pipeline.bestMatch(in: scored, threshold: matchThreshold) {
+                consecutiveWrongFaceFrames = 0
+                readyMatch = matched
+            } else {
+                readyMatch = nil
+                consecutiveWrongFaceFrames += 1
+                if consecutiveWrongFaceFrames >= wrongFaceStreakThreshold {
+                    authResult = .deny
+                    return authResult
+                }
+            }
+
+            if readyMatch != nil, livenessConfirmed {
+                authResult = .allow
+                return authResult
+            }
+
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+
+        authResult = .deny
+        return authResult
+    }
+}

--- a/pam_glance/Makefile
+++ b/pam_glance/Makefile
@@ -1,0 +1,29 @@
+# Builds pam_glance.so for Face-for-sudo.
+# Do NOT place the .so under glance/Resources in the source tree — Xcode's
+# synchronized group would link it and crash launch. The Xcode build phase
+# "Embed pam_glance" (or `make embed APP=...`) copies it into the built app.
+#
+# Usage:
+#   make -C pam_glance
+#   make -C pam_glance embed APP=/path/to/glance.app
+
+MODULE = pam_glance.so
+SRC = pam_glance.c
+
+CFLAGS ?= -Wall -Wextra -O2 -fPIC
+LDFLAGS ?= -dynamiclib -lpam
+
+.PHONY: all clean embed
+
+all: $(MODULE)
+
+$(MODULE): $(SRC)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
+
+# Manual embed into an already-built .app (CI / packaging).
+embed: $(MODULE)
+	@test -n "$(APP)" || (echo "usage: make -C pam_glance embed APP=/path/to/glance.app" >&2; exit 1)
+	./embed-resources.sh "$(APP)/Contents/Resources"
+
+clean:
+	rm -f $(MODULE)

--- a/pam_glance/README.md
+++ b/pam_glance/README.md
@@ -1,0 +1,37 @@
+# Face-for-sudo PAM module
+
+Built automatically by the Glance Xcode target (`Embed pam_glance` build phase).
+
+Manual build:
+
+```bash
+make -C pam_glance
+```
+
+## Cascade
+
+1. Face (Glance running, session unlocked)  
+2. Touch ID (`pam_tid.so`)  
+3. Password  
+
+## Enable
+
+1. Unlock the Glance session (menu bar).  
+2. Settings → General → **Face for sudo**.  
+3. Approve the admin prompt to install the PAM module into `/usr/local/lib/pam` and `/etc/pam.d/sudo_local`.
+
+If the in-app installer cannot write `sudo_local` (macOS restriction), from a Terminal with this repo:
+
+```bash
+make -C pam_glance
+sudo ./pam_glance/install.sh install ./pam_glance/pam_glance.so
+```
+
+## Test
+
+With Glance unlocked and Face for sudo on:
+
+```bash
+ls /tmp/com.jonathan.glance.sudoauth.*
+sudo -k && sudo -v
+```

--- a/pam_glance/embed-resources.sh
+++ b/pam_glance/embed-resources.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Called from the Xcode "Embed pam_glance" build phase.
+# Builds pam_glance.so and copies it + install.sh into the app Resources
+# folder (as resources, never linked into the binary).
+set -euo pipefail
+
+DEST="${1:?usage: embed-resources.sh <ResourcesDir>}"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+make -C "$ROOT" pam_glance.so
+
+mkdir -p "$DEST"
+cp "$ROOT/pam_glance.so" "$DEST/pam_glance.so"
+cp "$ROOT/install.sh" "$DEST/pam_glance_install.sh"
+chmod 755 "$DEST/pam_glance.so" "$DEST/pam_glance_install.sh"
+
+# Prefer the app's signing identity when Xcode provides one.
+if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ] && [ "${EXPANDED_CODE_SIGN_IDENTITY}" != "-" ]; then
+  codesign -f -s "${EXPANDED_CODE_SIGN_IDENTITY}" "$DEST/pam_glance.so" 2>/dev/null || true
+else
+  codesign -f -s - "$DEST/pam_glance.so" 2>/dev/null || true
+fi
+
+echo "note: embedded pam_glance into $DEST"

--- a/pam_glance/install.sh
+++ b/pam_glance/install.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Install or remove pam_glance for sudo Face auth.
+# Usage:
+#   install.sh install /path/to/pam_glance.so
+#   install.sh uninstall
+set -euo pipefail
+
+ACTION="${1:-}"
+MODULE_SRC="${2:-}"
+MODULE_DST="/usr/local/lib/pam/pam_glance.so"
+SUDO_LOCAL="/etc/pam.d/sudo_local"
+GLANCE_LINE="auth       sufficient     pam_glance.so"
+TID_LINE="auth       sufficient     pam_tid.so"
+
+ensure_sudo_local() {
+  if [[ -f "$SUDO_LOCAL" ]]; then
+    return
+  fi
+  if [[ -f /etc/pam.d/sudo_local.template ]]; then
+    sed -e 's/^#auth/auth/' /etc/pam.d/sudo_local.template > "$SUDO_LOCAL"
+  else
+    printf '%s\n' "# sudo_local: local config for sudo" "$TID_LINE" > "$SUDO_LOCAL"
+  fi
+  chmod 644 "$SUDO_LOCAL"
+}
+
+install_module() {
+  if [[ -z "$MODULE_SRC" || ! -f "$MODULE_SRC" ]]; then
+    echo "missing pam_glance.so source" >&2
+    exit 1
+  fi
+  mkdir -p /usr/local/lib/pam
+  cp "$MODULE_SRC" "$MODULE_DST"
+  chmod 755 "$MODULE_DST"
+
+  ensure_sudo_local
+
+  TMP="$(mktemp)"
+  # Drop any existing pam_glance lines.
+  grep -v 'pam_glance\.so' "$SUDO_LOCAL" > "$TMP" || true
+
+  # Ensure an uncommented pam_tid line exists.
+  if ! grep -Eq '^[[:space:]]*auth[[:space:]].*pam_tid\.so' "$TMP"; then
+    if grep -Eq '^[[:space:]]*#auth[[:space:]].*pam_tid\.so' "$TMP"; then
+      sed -i '' 's/^[[:space:]]*#auth\(.*pam_tid\.so\)/auth\1/' "$TMP"
+    else
+      printf '%s\n' "$TID_LINE" >> "$TMP"
+    fi
+  fi
+
+  # Insert pam_glance before the first auth line.
+  # Write via a file in /tmp then cp (mv from mktemp can hit SIP/TCC denies on /etc/pam.d).
+  TMP2="/tmp/sudo_local.glance.$$"
+  INSERTED=0
+  : > "$TMP2"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ $INSERTED -eq 0 && "$line" =~ ^[[:space:]]*auth ]]; then
+      printf '%s\n' "$GLANCE_LINE" >> "$TMP2"
+      INSERTED=1
+    fi
+    printf '%s\n' "$line" >> "$TMP2"
+  done < "$TMP"
+  if [[ $INSERTED -eq 0 ]]; then
+    printf '%s\n' "$GLANCE_LINE" >> "$TMP2"
+  fi
+  cp "$TMP2" "$SUDO_LOCAL"
+  chmod 644 "$SUDO_LOCAL"
+  rm -f "$TMP" "$TMP2"
+  echo "installed"
+}
+
+uninstall_module() {
+  if [[ -f "$SUDO_LOCAL" ]]; then
+    TMP="$(mktemp)"
+    grep -v 'pam_glance\.so' "$SUDO_LOCAL" > "$TMP" || true
+    mv "$TMP" "$SUDO_LOCAL"
+    chmod 644 "$SUDO_LOCAL"
+  fi
+  echo "uninstalled"
+}
+
+case "$ACTION" in
+  install) install_module ;;
+  uninstall) uninstall_module ;;
+  *)
+    echo "usage: $0 install <pam_glance.so> | uninstall" >&2
+    exit 1
+    ;;
+esac

--- a/pam_glance/pam_glance.c
+++ b/pam_glance/pam_glance.c
@@ -1,0 +1,142 @@
+/*
+ * pam_glance — Face authentication for sudo via the Glance Mac app.
+ *
+ * Asks the user-session Glance process (Unix socket) to match a face.
+ * On ALLOW → PAM success. On DENY / UNAVAIL / error → PAM failure so the
+ * next sufficient module (pam_tid) or password can run.
+ *
+ * Socket: /tmp/com.jonathan.glance.sudoauth.<uid>
+ * Request: "AUTH <timeoutSeconds>\n"
+ * Response: "ALLOW" | "DENY" | "UNAVAIL"
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define PAM_SM_AUTH
+#include <security/pam_modules.h>
+#include <security/pam_appl.h>
+
+#define SERVICE_NAME "com.jonathan.glance.sudoauth"
+#define DEFAULT_TIMEOUT 8
+#define MAX_TIMEOUT 20
+
+static int connect_user_socket(uid_t uid) {
+    char path[160];
+    snprintf(path, sizeof(path), "/tmp/%s.%u", SERVICE_NAME, (unsigned)uid);
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static int read_full_line(int fd, char *buf, size_t buflen, int timeout_sec) {
+    struct timeval tv;
+    tv.tv_sec = timeout_sec;
+    tv.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    size_t filled = 0;
+    while (filled + 1 < buflen) {
+        ssize_t n = read(fd, buf + filled, 1);
+        if (n <= 0) {
+            return -1;
+        }
+        if (buf[filled] == '\n') {
+            buf[filled] = '\0';
+            return 0;
+        }
+        filled++;
+    }
+    buf[buflen - 1] = '\0';
+    return -1;
+}
+
+static int glance_authenticate(uid_t uid, unsigned timeout) {
+    int fd = connect_user_socket(uid);
+    if (fd < 0) {
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    char req[32];
+    snprintf(req, sizeof(req), "AUTH %u\n", timeout);
+    if (write(fd, req, strlen(req)) < 0) {
+        close(fd);
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    /* Wait a little longer than the face scan so ALLOW can still arrive. */
+    char resp[32];
+    if (read_full_line(fd, resp, sizeof(resp), (int)timeout + 3) < 0) {
+        close(fd);
+        return PAM_AUTH_ERR;
+    }
+    close(fd);
+
+    if (strcmp(resp, "ALLOW") == 0) {
+        return PAM_SUCCESS;
+    }
+    if (strcmp(resp, "UNAVAIL") == 0) {
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+    return PAM_AUTH_ERR;
+}
+
+PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags,
+                                   int argc, const char **argv) {
+    (void)flags;
+
+    unsigned timeout = DEFAULT_TIMEOUT;
+    for (int i = 0; i < argc; i++) {
+        if (strncmp(argv[i], "timeout=", 8) == 0) {
+            unsigned v = (unsigned)atoi(argv[i] + 8);
+            if (v >= 1 && v <= MAX_TIMEOUT) {
+                timeout = v;
+            }
+        }
+    }
+
+    const char *user = NULL;
+    if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS || user == NULL) {
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    struct passwd *pw = getpwnam(user);
+    if (pw == NULL) {
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    int rc = glance_authenticate(pw->pw_uid, timeout);
+    /* sufficient modules treat any non-success as "try next". */
+    return rc;
+}
+
+PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags,
+                              int argc, const char **argv) {
+    (void)pamh;
+    (void)flags;
+    (void)argc;
+    (void)argv;
+    return PAM_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- Adds optional Face authentication for `sudo` via a PAM module (`pam_glance`) that talks to the running Glance app over a Unix socket.
- Cascade: Face (session unlocked) → Touch ID (`pam_tid`) → password.
- Settings toggle under General; notch scan animation during sudo face auth; orphaned Keychain recovery UI on Password tab.

## Notes
- Mode A: Face for sudo only works while Glance is running with an unlocked Touch ID session.
- Build PAM with `make -C pam_glance`; embed into the app with `make -C pam_glance embed APP=...`.
- Writing `/etc/pam.d/sudo_local` may need Terminal (`./pam_glance/fix-sudo-local.sh`) if the in-app installer is blocked by macOS.

## Test plan
- [ ] `make -C pam_glance` and run Glance from this branch
- [ ] Unlock session → enable Face for sudo
- [ ] Confirm `ls /tmp/com.jonathan.glance.sudoauth.*` shows a socket
- [ ] `sudo -k && sudo -v` → face / notch, then Touch ID on fail, password on cancel
- [ ] Quit Glance → `sudo -v` skips face → Touch ID
