### PR TITLE
Support external cameras when the built-in one is suspended

### DIFF
--- a/glance/CameraDeviceCatalog.swift
+++ b/glance/CameraDeviceCatalog.swift
@@ -11,16 +11,41 @@ import AppKit
 struct CameraDevice: Identifiable, Hashable {
     let id: String // AVCaptureDevice.uniqueID
     let name: String
+    /// False for a device macOS lists but can't actually deliver frames from —
+    /// in practice the built-in FaceTime camera while the lid is closed.
+    let isUsable: Bool
 }
 
 enum CameraDeviceCatalog {
-    static func availableDevices() -> [CameraDevice] {
-        let discovery = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.builtInWideAngleCamera, .external, .continuityCamera],
+    private static let deviceTypes: [AVCaptureDevice.DeviceType] = [
+        .builtInWideAngleCamera, .external, .continuityCamera
+    ]
+
+    private static func discoveredDevices() -> [AVCaptureDevice] {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: deviceTypes,
             mediaType: .video,
             position: .unspecified
-        )
-        return discovery.devices.map { CameraDevice(id: $0.uniqueID, name: $0.localizedName) }
+        ).devices
+    }
+
+    /// A clamshelled MacBook still *reports* its built-in camera as connected; it's
+    /// only `isSuspended` that gives it away. Opening one produces a session that
+    /// runs but never publishes a frame — a black preview with no error.
+    private static func isUsable(_ device: AVCaptureDevice) -> Bool {
+        device.isConnected && !device.isSuspended
+    }
+
+    static func availableDevices() -> [CameraDevice] {
+        discoveredDevices().map {
+            CameraDevice(id: $0.uniqueID, name: $0.localizedName, isUsable: isUsable($0))
+        }
+    }
+
+    /// Devices that can actually deliver frames right now — what a picker shown
+    /// during onboarding should offer.
+    static func usableDevices() -> [CameraDevice] {
+        availableDevices().filter(\.isUsable)
     }
 
     /// True if the currently-active screen is the Mac's built-in display
@@ -33,17 +58,33 @@ enum CameraDeviceCatalog {
         return CGDisplayIsBuiltin(screenNumber) != 0
     }
 
-    /// Display-specific override, then flat default, then the system default camera.
+    /// Display-specific override, then flat default, then the best usable camera.
+    ///
+    /// Every stage is filtered through `isUsable`, so a saved preference pointing at
+    /// a camera that's currently unavailable (unplugged dock, closed lid) degrades to
+    /// the next candidate instead of opening a device that will never produce frames.
     static func resolvedDevice() -> AVCaptureDevice? {
         let settings = GlanceSettings.shared
         let preferredID = isUsingBuiltInDisplay()
             ? (settings.builtInDisplayCameraID ?? settings.defaultCameraID)
             : (settings.externalDisplayCameraID ?? settings.defaultCameraID)
 
-        if let preferredID, let device = AVCaptureDevice(uniqueID: preferredID) {
+        if let preferredID, let device = AVCaptureDevice(uniqueID: preferredID), isUsable(device) {
             return device
         }
-        return AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front)
-            ?? AVCaptureDevice.default(for: .video)
+
+        if let builtIn = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front),
+           isUsable(builtIn) {
+            return builtIn
+        }
+
+        // Clamshell/headless case: no usable built-in, so take whatever external or
+        // Continuity camera is attached.
+        if let external = discoveredDevices().first(where: isUsable) {
+            return external
+        }
+
+        let systemDefault = AVCaptureDevice.default(for: .video)
+        return systemDefault.map(isUsable) == true ? systemDefault : nil
     }
 }

--- a/glance/CameraManager.swift
+++ b/glance/CameraManager.swift
@@ -39,9 +39,38 @@ final class CameraManager: NSObject {
     /// Handed to the delegate outside the actor; only ever touched via `Task { @MainActor ... }`.
     private let framePublisher = FramePublisher()
 
+    /// Held in a box rather than a stored array so teardown can happen in the box's own
+    /// `deinit` — this class is `@MainActor`, and its `deinit` is not, so it can't touch
+    /// isolated state to unregister.
+    private final class ObserverBox: @unchecked Sendable {
+        var tokens: [NSObjectProtocol] = []
+        deinit { tokens.forEach(NotificationCenter.default.removeObserver) }
+    }
+
+    private let deviceObservers = ObserverBox()
+
     override init() {
         super.init()
         framePublisher.owner = self
+        observeDeviceChanges()
+    }
+
+    /// Docking, undocking, or opening the lid changes which camera `CameraDeviceCatalog`
+    /// would resolve to. Without this the session keeps whatever device it opened at
+    /// `start()` — which, for a camera that went away, means frames simply stop.
+    private func observeDeviceChanges() {
+        let names: [Notification.Name] = [
+            AVCaptureDevice.wasConnectedNotification,
+            AVCaptureDevice.wasDisconnectedNotification,
+        ]
+        deviceObservers.tokens = names.map { name in
+            NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    guard let self, self.isRunning else { return }
+                    self.reconcileDeviceIfNeeded()
+                }
+            }
+        }
     }
 
     func start() async {

--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -341,6 +341,48 @@ final class OnboardingController {
 
     private var permissionsPollTask: Task<Void, Never>?
 
+    // MARK: - Camera selection
+    //
+    // Settings' camera page is unreachable until onboarding finishes, so without a
+    // picker here a clamshelled Mac has no way to enroll: its built-in camera is still
+    // listed by AVFoundation, just suspended, and enrollment sits on a black preview.
+
+    /// Only cameras that can deliver frames right now — a suspended built-in camera
+    /// is exactly what we're trying to steer the user away from.
+    private(set) var availableCameras: [CameraDevice] = []
+
+    /// Nil means "let `CameraDeviceCatalog` decide". Reads through to settings so the
+    /// choice made here is the same one the unlock flow uses afterward.
+    var selectedCameraID: String? { GlanceSettings.shared.defaultCameraID }
+
+    /// Name of the camera enrollment will actually open, resolved the same way
+    /// `CameraManager` resolves it.
+    var resolvedCameraName: String {
+        guard let device = CameraDeviceCatalog.resolvedDevice() else { return "No camera found" }
+        return device.localizedName
+    }
+
+    func refreshCameras() {
+        // A saved pick that's no longer usable isn't cleared — `resolvedCameraName`
+        // already reports the fallback, and silently discarding a Settings choice
+        // because a dock is unplugged would be worse than showing it as inactive.
+        availableCameras = CameraDeviceCatalog.usableDevices()
+    }
+
+    /// `nil` restores automatic selection. Restarts the capture session when enrollment
+    /// is already live so the swap is visible immediately.
+    func selectCamera(_ id: String?) {
+        GlanceSettings.shared.defaultCameraID = id
+        // The per-display overrides would silently win over this pick on the very next
+        // resolve; onboarding's choice is meant to be the one that sticks.
+        GlanceSettings.shared.builtInDisplayCameraID = nil
+        GlanceSettings.shared.externalDisplayCameraID = nil
+
+        guard step == .enroll else { return }
+        camera.stop()
+        Task { await camera.start() }
+    }
+
     // MARK: - Enrollment
 
     /// 9 poses x 2 samples = 18 total, enough for a stable template without overlong holds.

--- a/glance/Onboarding/OnboardingControls.swift
+++ b/glance/Onboarding/OnboardingControls.swift
@@ -191,3 +191,66 @@ private func firstTextField(in view: NSView) -> NSView? {
     }
     return nil
 }
+
+/// Camera chooser shown on the pre-setup step. Onboarding runs before Settings is
+/// reachable, so on a docked/clamshelled Mac this is the only place to point
+/// enrollment at a USB camera instead of the suspended built-in one.
+struct CameraPickerRow: View {
+    let controller: OnboardingController
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "video.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(GlanceTheme.textDetail)
+                .frame(width: OnboardingMetrics.statusDotSize)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Camera")
+                    .font(GlanceTheme.Font.rowTitle)
+                    .foregroundStyle(GlanceTheme.textPrimary)
+                Text(controller.resolvedCameraName)
+                    .font(GlanceTheme.Font.rowDetail)
+                    .foregroundStyle(GlanceTheme.textDetail)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 4)
+
+            Menu {
+                Button("Automatic") { controller.selectCamera(nil) }
+                ForEach(controller.availableCameras) { device in
+                    Button(device.name) { controller.selectCamera(device.id) }
+                }
+            } label: {
+                Text("Change")
+                    .font(GlanceTheme.Font.grantLabel)
+                    .foregroundStyle(GlanceTheme.textPrimary)
+                    .frame(
+                        width: OnboardingMetrics.grantButtonSize.width,
+                        height: OnboardingMetrics.grantButtonSize.height
+                    )
+                    .background(GlanceTheme.surfaceRaised)
+                    .clipShape(Capsule())
+                    .contentShape(Capsule())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .buttonStyle(.plain)
+            .fixedSize()
+            // Window accent tint otherwise paints the menu label blue.
+            .tint(GlanceTheme.textPrimary)
+            // A single camera and nothing to switch to — keep the row as a
+            // statement of what will be used rather than a dead control.
+            .disabled(controller.availableCameras.count < 2)
+            .opacity(controller.availableCameras.count < 2 ? 0.4 : 1)
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity)
+        .frame(height: OnboardingMetrics.permissionRowHeight)
+        .background(GlanceTheme.surface)
+        .clipShape(Capsule())
+        .onAppear { controller.refreshCameras() }
+    }
+}

--- a/glance/Onboarding/OnboardingMetrics.swift
+++ b/glance/Onboarding/OnboardingMetrics.swift
@@ -33,8 +33,8 @@ enum OnboardingMetrics {
     static let pillPermissionsHeight: CGFloat = 245
     static let notchSecurityNoticeHeight: CGFloat = 260
     static let pillSecurityNoticeHeight: CGFloat = 260
-    static let notchPreSetupHeight: CGFloat = 220
-    static let pillPreSetupHeight: CGFloat = 220
+    static let notchPreSetupHeight: CGFloat = 272
+    static let pillPreSetupHeight: CGFloat = 272
     static let notchEnrollHeight: CGFloat = 344
     static let pillEnrollHeight: CGFloat = 350
     static let notchNameHeight: CGFloat = 230

--- a/glance/Onboarding/OnboardingStepViews.swift
+++ b/glance/Onboarding/OnboardingStepViews.swift
@@ -168,6 +168,10 @@ struct PreSetupStepView: View {
                 UnlockGlyphView()
                     .frame(width: 120, height: 120)
             }
+
+            CameraPickerRow(controller: controller)
+                .padding(.top, 2)
+
             Spacer(minLength: 4)
 
             HStack(spacing: 10) {

--- a/glance/Settings/Pages/CameraSettingsPage.swift
+++ b/glance/Settings/Pages/CameraSettingsPage.swift
@@ -139,7 +139,11 @@ struct CameraSettingsPage: View {
                 Menu {
                     Button("System default") { selection.wrappedValue = nil }
                     ForEach(devices) { device in
-                        Button(device.name) { selection.wrappedValue = device.id }
+                        // Still selectable — a camera that's unplugged right now
+                        // is a legitimate pick for the config you usually run in.
+                        Button(device.isUsable ? device.name : "\(device.name) (unavailable)") {
+                            selection.wrappedValue = device.id
+                        }
                     }
                 } label: {
                     HStack(spacing: 6) {


### PR DESCRIPTION
Fixes #16.

## The bug

A clamshelled MacBook still reports its built-in camera as *connected*. Only `isSuspended` gives it away:

```
USB Camera          type=External   connected=true  suspended=false
MacBook Pro Camera  type=BuiltIn    connected=true  suspended=true   ← lid closed
default(.builtInWideAngleCamera, .front) = MacBook Pro Camera        ← what resolvedDevice() picked
default(for: .video)                     = USB Camera
```

`CameraDeviceCatalog.resolvedDevice()` fell back to `AVCaptureDevice.default(.builtInWideAngleCamera, .front)`, which is exactly the state during first-run onboarding, when no camera preference is saved yet. The session opened fine and started running — it just never published a frame. Enrollment showed a black preview and no error, and there was no way forward: Settings' camera picker isn't reachable until onboarding completes, so a docked user was stuck with `onboardingResumeStep = preSetup` on every relaunch.

## The fix

**`CameraDeviceCatalog`** — every resolution stage now filters through `isConnected && !isSuspended`. A saved preference naming a camera that's currently unavailable (unplugged dock, closed lid) degrades to the next candidate rather than opening a device that can't deliver frames, and the clamshell case falls through to the first usable external/Continuity camera. Adds `usableDevices()` and an `isUsable` flag on `CameraDevice`.

**Onboarding camera picker** — a new `CameraPickerRow` on the pre-setup step names the camera enrollment will actually open, with a *Change* menu listing the usable devices. Picking there writes `defaultCameraID` and clears the per-display overrides, which would otherwise silently win on the very next resolve. The row reuses `PermissionRow`'s capsule chrome; `preSetup` panel height goes 220 → 272 to fit it. The menu disables itself when there's only one camera, so it reads as a statement of what will be used rather than a dead control.

**Hot-plug** — `CameraManager` re-resolves its device on `AVCaptureDevice.wasConnected` / `wasDisconnected`, so docking or undocking no longer needs an app restart. Observer tokens live in a small box class so teardown can happen in its `deinit` (the `@MainActor` class's own `deinit` can't touch isolated state).

**Settings** — currently-unavailable devices are labelled `(unavailable)` in the camera menu but stay selectable, since an unplugged camera is a legitimate pick for the configuration you usually run in.

## Testing

Built and ran on a docked MacBook Pro (lid closed, external display, USB webcam). Onboarding renders in pill style on the external display, the camera row resolves to *USB Camera* automatically, and enrollment gets a live feed. The suspended built-in camera is filtered out of the picker entirely.

Not covered: I have no way to test Continuity Camera or a multi-external-display setup.

https://claude.ai/code/session_01TPWwbaYdRP97k83GRUXkuA
