### PR TITLE
Add option to show/hide menu bar icon

### DIFF
--- a/glance/Settings/GlanceSettings.swift
+++ b/glance/Settings/GlanceSettings.swift
@@ -89,7 +89,10 @@ enum UnlockTrigger: String, CaseIterable, Identifiable {
 final class GlanceSettings {
     static let shared = GlanceSettings()
 
+    static let menuBarVisibilityDidChangeNotification = Notification.Name("GlanceSettings.menuBarVisibilityDidChangeNotification")
+
     private enum Key {
+        static let showMenuBarIcon = "GlanceSettings.showMenuBarIcon"
         static let isFaceUnlockEnabled = "GlanceSettings.isFaceUnlockEnabled"
         static let matchThreshold = "GlanceSettings.matchThreshold"
         static let livenessChecksEnabled = "GlanceSettings.livenessChecksEnabled"
@@ -117,6 +120,12 @@ final class GlanceSettings {
 
     @ObservationIgnored private let defaults = UserDefaults.standard
 
+    var showMenuBarIcon: Bool {
+        didSet {
+            defaults.set(showMenuBarIcon, forKey: Key.showMenuBarIcon)
+            NotificationCenter.default.post(name: Self.menuBarVisibilityDidChangeNotification, object: showMenuBarIcon)
+        }
+    }
     var isFaceUnlockEnabled: Bool {
         didSet { defaults.set(isFaceUnlockEnabled, forKey: Key.isFaceUnlockEnabled) }
     }
@@ -253,6 +262,7 @@ final class GlanceSettings {
     }
 
     private init() {
+        showMenuBarIcon = defaults.object(forKey: Key.showMenuBarIcon) as? Bool ?? true
         // Enabled by default — onboarding already enrolled a face and set a
         // password specifically to use Face Unlock.
         isFaceUnlockEnabled = defaults.object(forKey: Key.isFaceUnlockEnabled) as? Bool ?? true

--- a/glance/Settings/Pages/GeneralSettingsPage.swift
+++ b/glance/Settings/Pages/GeneralSettingsPage.swift
@@ -48,6 +48,10 @@ struct GeneralSettingsPage: View {
                 ))
             }
             SettingsGroupDivider()
+            SettingsRowContent(title: "Show menu bar icon") {
+                GlanceToggle(isOn: $settings.showMenuBarIcon)
+            }
+            SettingsGroupDivider()
             SettingsRowContent(title: "Enable Face Unlock") {
                 GlanceToggle(isOn: $coordinator.isEnabled)
             }
@@ -76,6 +80,9 @@ struct GeneralSettingsPage: View {
         }
         if let launchAtLoginError {
             SettingsCaption(text: launchAtLoginError)
+        }
+        if !settings.showMenuBarIcon {
+            SettingsCaption(text: "Menu bar icon is hidden. Launch Glance from Spotlight or Applications to open Settings.")
         }
         if hasInheritedXcodePermission {
             SettingsCaption(text: "Running from Xcode — permission checks resolve against Xcode’s grants, not glance’s, so this reading is meaningless. Launch glance.app on its own to see the real state.")

--- a/glance/glanceApp.swift
+++ b/glance/glanceApp.swift
@@ -104,6 +104,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         item.menu = menu
         statusItem = item
+        statusItem?.isVisible = GlanceSettings.shared.showMenuBarIcon
+
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(menuBarVisibilityDidChange(_:)),
+            name: GlanceSettings.menuBarVisibilityDidChangeNotification, object: nil
+        )
 
         updateSessionMenuItem()
 
@@ -211,14 +217,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
     }
 
+    @objc private func menuBarVisibilityDidChange(_ notification: Notification) {
+        let isVisible = notification.object as? Bool ?? GlanceSettings.shared.showMenuBarIcon
+        statusItem?.isVisible = isVisible
+    }
+
     /// Keeps the process alive after the window closes so it can still react to the screen locking (e.g. for face unlock).
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return false
     }
 
-    /// A Dock click must not create the Settings window — that produced a duplicate Recents icon. If already open, the default
-    /// reopen behavior just brings it forward.
+    /// Reopening the app (e.g. via Spotlight or Finder) reveals the Settings window if no window
+    /// is currently visible. This ensures users can always access settings even if the menu bar icon is hidden.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            revealSettingsWindow()
+            return true
+        }
         return flag
     }
 


### PR DESCRIPTION
### Overview
Adds an option to show or hide Glance's menu bar icon.

### Changes
- **Persistence**: Adds `showMenuBarIcon` (defaults to `true`) in `GlanceSettings`, persisted to `UserDefaults`.
- **UI**: Adds a **Show menu bar icon** toggle under **General Settings** with guidance explaining how to reopen Settings when hidden.
- **Dynamic Visibility**: Updates `NSStatusItem.isVisible` dynamically via `NotificationCenter` whenever the preference is changed.
- **Relaunch Handling**: Updates `applicationShouldHandleReopen` so launching Glance from Spotlight or Applications while it is running brings Settings forward when no window is visible, ensuring users are never locked out.