### PR TITLE
Clear the password field and modifier flags before injecting (#7)

### DIFF
--- a/glance/KeystrokeInjector.swift
+++ b/glance/KeystrokeInjector.swift
@@ -47,10 +47,41 @@ enum KeystrokeInjector {
             throw KeystrokeError.eventCreationFailed
         }
         let source = CGEventSource(stateID: .hidSystemState)
+        // Whatever woke the Mac — a keypress, a trackpad tap that landed on the field — is already sitting in the
+        // password box. Typing on top of it appends, so the field holds `<junk><password>` and login rejects a password
+        // the user knows is right.
+        try clearFocusedField(source: source)
         for char in text {
             try postUnicode(String(char), source: source)
         }
         try postReturn(source: source)
+    }
+
+    /// Select-all then delete, so injection always starts from an empty field.
+    private nonisolated static func clearFocusedField(source: CGEventSource?) throws {
+        let aKey: CGKeyCode = 0x00
+        let deleteKey: CGKeyCode = 0x33
+
+        guard let selectDown = CGEvent(keyboardEventSource: source, virtualKey: aKey, keyDown: true),
+              let selectUp = CGEvent(keyboardEventSource: source, virtualKey: aKey, keyDown: false),
+              let deleteDown = CGEvent(keyboardEventSource: source, virtualKey: deleteKey, keyDown: true),
+              let deleteUp = CGEvent(keyboardEventSource: source, virtualKey: deleteKey, keyDown: false) else {
+            throw KeystrokeError.eventCreationFailed
+        }
+
+        selectDown.flags = .maskCommand
+        selectUp.flags = .maskCommand
+        deleteDown.flags = []
+        deleteUp.flags = []
+
+        selectDown.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: keyInterval)
+        selectUp.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: keyInterval)
+        deleteDown.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: keyInterval)
+        deleteUp.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: keyInterval)
     }
 
     /// Per-character Unicode injection — bypasses keyboard layout issues.
@@ -60,6 +91,10 @@ enum KeystrokeInjector {
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
             throw KeystrokeError.eventCreationFailed
         }
+        // `.hidSystemState` events inherit the live hardware modifier state, so Caps Lock — or a modifier the user is
+        // still physically holding from waking the Mac — rides along and corrupts every character.
+        keyDown.flags = []
+        keyUp.flags = []
         utf16.withUnsafeBufferPointer { buf in
             if let base = buf.baseAddress {
                 keyDown.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: base)
@@ -67,9 +102,9 @@ enum KeystrokeInjector {
             }
         }
         keyDown.post(tap: .cghidEventTap)
-        Thread.sleep(forTimeInterval: 0.012)
+        Thread.sleep(forTimeInterval: keyInterval)
         keyUp.post(tap: .cghidEventTap)
-        Thread.sleep(forTimeInterval: 0.012)
+        Thread.sleep(forTimeInterval: keyInterval)
     }
 
     /// Physical Return key (virtual key 0x24).
@@ -79,8 +114,13 @@ enum KeystrokeInjector {
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: returnKey, keyDown: false) else {
             throw KeystrokeError.eventCreationFailed
         }
+        // A held Shift or Control turns this into a different shortcut and the field never submits.
+        keyDown.flags = []
+        keyUp.flags = []
         keyDown.post(tap: .cghidEventTap)
-        Thread.sleep(forTimeInterval: 0.012)
+        Thread.sleep(forTimeInterval: keyInterval)
         keyUp.post(tap: .cghidEventTap)
     }
+
+    private nonisolated static let keyInterval: TimeInterval = 0.012
 }


### PR DESCRIPTION
Fixes what I believe are two independent causes of #7 — a correct stored password being rejected at the lock screen.

### 1. The password field is never cleared before injection

`typeAndReturn` types straight into whatever has keyboard focus. But waking a Mac almost always means pressing a key or tapping the trackpad, and that input lands in the password field *before* glance runs. Injection then appends to it, so login sees `<stray char><password>` and rejects a password the user knows is correct.

This matches the question you asked the reporter about pre-existing text in the field. If it's the cause, it isn't something a user can avoid — the keypress that wakes the machine is the same keypress that dirties the field.

Adds `clearFocusedField()` (select-all, then delete) ahead of typing.

### 2. Injected events inherit live hardware modifier state

`CGEventSource(stateID: .hidSystemState)` means every synthesized event picks up whatever modifiers are physically active. Caps Lock, or a modifier still held from waking the machine, rides along on all character events — and on the final Return, where a held Shift or Control means the field never submits at all.

Sets `.flags = []` explicitly on every injected event.

Also lifts the repeated `0.012` sleep into a `keyInterval` constant.

### Verification — please read before merging

- Applies cleanly to `main`
- `swiftc -typecheck` passes on the file
- **Not built in Xcode, and not tested against a live lock screen.** I don't have a way to exercise the loginwindow path, so the diagnosis is from reading the code, not from watching it fail and then pass.

### One thing I could not check

Every character event uses `virtualKey: 0` (the `a` key) with the real character supplied via `keyboardSetUnicodeString`. If the loginwindow secure field ever re-translates from the keycode rather than honoring the unicode string, the whole password would arrive as a row of `a`s. That would be a separate, larger fix — worth looking at if reports persist after this.

I saw the README says you're not taking PRs; happy for this to just be a diagnosis you reimplement however you prefer. Closing it is completely fine.
