### PR TITLE
Add Night Boost: unlock in a dark room

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Open the `.dmg` file and drag Glance to `/Applications`, then open it.
 | **Camera & display** | Choose which camera to use, including different cameras for the built-in display vs. an external monitor. |
 | **Auto-locking sessions** | The Touch ID session re-locks itself after an idle period you choose, so an unattended Mac doesn't stay authorized forever. |
 | **Trackpad haptics** | Hovering over the notch will trigger haptics |
+| **Night boost** | Works in a dark room: the top third of the display becomes a warm flood light for the length of the scan (brightness raised and restored afterwards, password field left clear), the camera is allowed to drop to 15 fps for a longer exposure, and frames are denoised and gained up before recognition. Frames captured while the light is still coming up are skipped rather than judged. Toggle under General → Night. |
 | **Notchless Mac support** | Macs without a notch will be replaced with a pill-shape, dynamic island style design. |
 | **Your data, your call** | Edit or delete your enrolment or stored password at any time. The encrypted files are removed immediately. |
 

--- a/glance/CameraDeviceCatalog.swift
+++ b/glance/CameraDeviceCatalog.swift
@@ -33,6 +33,21 @@ enum CameraDeviceCatalog {
         return CGDisplayIsBuiltin(screenNumber) != 0
     }
 
+    /// The screen the active camera physically sits on — the only display whose light actually reaches the user's face.
+    /// `nil` when that can't be determined, so callers skip illuminating rather than light a monitor the camera is not
+    /// facing (which would backlight the subject and make auto-exposure pull the face *darker*).
+    static func screenForActiveCamera() -> NSScreen? {
+        guard let device = resolvedDevice() else { return nil }
+        guard device.deviceType == .builtInWideAngleCamera else {
+            // An external or Continuity camera can sit anywhere; the display it faces is unknowable from here.
+            return nil
+        }
+        return NSScreen.screens.first {
+            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID)
+                .map { CGDisplayIsBuiltin($0) != 0 } ?? false
+        }
+    }
+
     /// Display-specific override, then flat default, then the system default camera.
     static func resolvedDevice() -> AVCaptureDevice? {
         let settings = GlanceSettings.shared

--- a/glance/CameraManager.swift
+++ b/glance/CameraManager.swift
@@ -21,6 +21,13 @@ struct CameraFrame {
     let image: CGImage
     let source: CIImage
     let sourceSize: CGSize
+    /// The working frame *before* `LowLightEnhancer`, for anything that must judge what the sensor really saw rather
+    /// than what we brightened — the liveness deny cues. Identical to `image` whenever no enhancement was applied.
+    var rawImage: CGImage
+    /// Mean luma of the raw working frame (before any enhancement), 0…1 — see `SceneLuminance`. 1 if unmeasurable.
+    var meanLuminance: Float = 1
+    /// True when `image` had `LowLightEnhancer` applied; `source` and `rawImage` are always ungained.
+    var isLowLightEnhanced: Bool = false
 }
 
 @Observable
@@ -30,6 +37,9 @@ final class CameraManager: NSObject {
     private(set) var isRunning: Bool = false
     private(set) var currentFrame: CameraFrame?
     private(set) var errorMessage: String?
+    /// Advisory only — never gates a scan. `errorMessage` means "no usable camera"; this means "the camera works, but
+    /// something optional didn't apply". Surfaced by Settings/Face Lab, ignored by the unlock path.
+    private(set) var frameRateNote: String?
 
     /// Exposed read-only so `CameraPreviewView` can attach a preview layer to the same session.
     let session = AVCaptureSession()
@@ -67,6 +77,9 @@ final class CameraManager: NSObject {
         errorMessage = nil
         configureSessionIfNeeded()
         reconcileDeviceIfNeeded()
+        // After reconcile, not inside it: `reconcileDeviceIfNeeded` early-returns when the device is unchanged, so folding
+        // this in there would leave the frame-rate policy stuck at whatever Night Boost was set to on the first scan.
+        applyFrameRatePolicy()
 
         sessionQueue.async { [session] in
             if !session.isRunning {
@@ -159,6 +172,39 @@ final class CameraManager: NSObject {
         }
     }
 
+    /// The built-in camera pins itself to 30 fps (min == max frame duration on every format this Mac reports), which caps
+    /// its auto-exposure at ~33 ms and is why a dark room arrives as noise. With Night Boost on, raising only the *max*
+    /// frame duration to 1/15 s lets the ISP drop to 15 fps and double the exposure when — and only when — the scene is
+    /// dark; a lit room stays at 30 fps. With it off, the max is pinned back to the format's own floor so the setting takes
+    /// effect on the next scan rather than the next launch. Re-applied on every `start()` since setting `activeFormat`
+    /// resets both durations.
+    private func applyFrameRatePolicy() {
+        guard let device = currentInput?.device else { return }
+        let slowest = CMTime(value: 1, timescale: 15)
+        let canSlowDown = device.activeFormat.videoSupportedFrameRateRanges.contains {
+            CMTimeCompare($0.maxFrameDuration, slowest) >= 0
+        }
+        // `.invalid` means "your own default" to AVCaptureDevice. Computing a concrete off-value instead would pin the
+        // device to whatever that value was — on a 60 fps webcam, switching Night Boost off would lock it at 60 fps.
+        let target = (GlanceSettings.shared.nightBoostEnabled && canSlowDown) ? slowest : CMTime.invalid
+        guard CMTimeCompare(device.activeVideoMaxFrameDuration, target) != 0 else { return }
+
+        do {
+            try device.lockForConfiguration()
+            defer { device.unlockForConfiguration() }
+            // Order matters: max must never sit below min, so widen from the min side first.
+            if target.isValid, CMTimeCompare(target, device.activeVideoMinFrameDuration) < 0 {
+                device.activeVideoMinFrameDuration = target
+            }
+            device.activeVideoMaxFrameDuration = target
+        } catch {
+            // Genuinely non-fatal, so it must NOT reach `errorMessage`: `FaceUnlockCoordinator.runScanCycle` aborts the
+            // whole scan on any non-nil `errorMessage`, so reporting a failed frame-rate hint there would disable face
+            // unlock entirely whenever another app (FaceTime, Zoom) holds the device's configuration lock.
+            frameRateNote = "Couldn't set the camera's low-light frame rate: \(error.localizedDescription)"
+        }
+    }
+
     fileprivate func publish(frame: CameraFrame) {
         currentFrame = frame
     }
@@ -224,14 +270,26 @@ final class CameraManager: NSObject {
                 let scale = maxLongEdge / longEdge
                 ciImage = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
             }
-            guard let cgImage = ciContext.createCGImage(ciImage, from: ciImage.extent) else { return }
+
+            // Night boost: measure the raw working frame, then gain it up if the room is dark. The native `source`
+            // stays untouched so the glare cue keeps reading real sensor highlights (see LowLightEnhancer.swift).
+            let meanLuminance = SceneLuminance.meanLuminance(of: ciImage, context: ciContext) ?? 1
+            let enhanced = LowLightEnhancer.enhance(ciImage, meanLuminance: meanLuminance)
+            let isEnhanced = enhanced !== ciImage
+            guard let cgImage = ciContext.createCGImage(enhanced, from: enhanced.extent) else { return }
+            // Second render only in a dark room: the bezel deny cue reads this, and gain applied to a dark frame can
+            // invent or erase the rectangle edges it keys on (LivenessFeatures.swift feeds it the working frame).
+            let rawCGImage = isEnhanced ? (ciContext.createCGImage(ciImage, from: ciImage.extent) ?? cgImage) : cgImage
 
             nextFrameID &+= 1
             let frame = CameraFrame(
                 id: nextFrameID,
                 image: cgImage,
                 source: sourceImage,
-                sourceSize: sourceExtent.size
+                sourceSize: sourceExtent.size,
+                rawImage: rawCGImage,
+                meanLuminance: meanLuminance,
+                isLowLightEnhanced: isEnhanced
             )
 
             Task { @MainActor [weak owner] in

--- a/glance/CameraManager.swift
+++ b/glance/CameraManager.swift
@@ -38,7 +38,7 @@ final class CameraManager: NSObject {
     private(set) var currentFrame: CameraFrame?
     private(set) var errorMessage: String?
     /// Advisory only — never gates a scan. `errorMessage` means "no usable camera"; this means "the camera works, but
-    /// something optional didn't apply". Surfaced by Settings/Face Lab, ignored by the unlock path.
+    /// something optional didn't apply". Shown on the Camera settings page beneath the preview, ignored by the unlock path.
     private(set) var frameRateNote: String?
 
     /// Exposed read-only so `CameraPreviewView` can attach a preview layer to the same session.
@@ -75,6 +75,7 @@ final class CameraManager: NSObject {
         }
 
         errorMessage = nil
+        frameRateNote = nil
         configureSessionIfNeeded()
         reconcileDeviceIfNeeded()
         // After reconcile, not inside it: `reconcileDeviceIfNeeded` early-returns when the device is unchanged, so folding
@@ -181,22 +182,40 @@ final class CameraManager: NSObject {
     private func applyFrameRatePolicy() {
         guard let device = currentInput?.device else { return }
         let slowest = CMTime(value: 1, timescale: 15)
+        // 15fps must fall *inside* a supported range. Testing only `maxFrameDuration >= 1/15` is not the same thing: a
+        // format capped at 10fps reports a maximum duration of 1/10s, which is longer than 1/15s and would pass, and we
+        // would then force a rate the device cannot produce.
         let canSlowDown = device.activeFormat.videoSupportedFrameRateRanges.contains {
-            CMTimeCompare($0.maxFrameDuration, slowest) >= 0
+            CMTimeCompare($0.minFrameDuration, slowest) <= 0 && CMTimeCompare(slowest, $0.maxFrameDuration) <= 0
         }
-        // `.invalid` means "your own default" to AVCaptureDevice. Computing a concrete off-value instead would pin the
-        // device to whatever that value was — on a 60 fps webcam, switching Night Boost off would lock it at 60 fps.
-        let target = (GlanceSettings.shared.nightBoostEnabled && canSlowDown) ? slowest : CMTime.invalid
-        guard CMTimeCompare(device.activeVideoMaxFrameDuration, target) != 0 else { return }
+        let wantsSlowdown = GlanceSettings.shared.nightBoostEnabled && canSlowDown
+
+        if wantsSlowdown {
+            guard CMTimeCompare(device.activeVideoMaxFrameDuration, slowest) != 0 else { return }
+        } else {
+            // Nothing to undo unless we were the ones who relaxed it. Tracked with a flag rather than compared against
+            // `.invalid`, which is not meaningfully comparable.
+            guard hasRelaxedFrameRate else { return }
+        }
 
         do {
             try device.lockForConfiguration()
             defer { device.unlockForConfiguration() }
-            // Order matters: max must never sit below min, so widen from the min side first.
-            if target.isValid, CMTimeCompare(target, device.activeVideoMinFrameDuration) < 0 {
-                device.activeVideoMinFrameDuration = target
+            if wantsSlowdown {
+                // Order matters: max must never sit below min, so widen from the min side first.
+                if CMTimeCompare(slowest, device.activeVideoMinFrameDuration) < 0 {
+                    device.activeVideoMinFrameDuration = slowest
+                }
+                device.activeVideoMaxFrameDuration = slowest
+                hasRelaxedFrameRate = true
+            } else {
+                // Both, not just the maximum: enabling can lower the minimum too, and leaving that behind would cap the
+                // camera at 15fps for the rest of the session after the setting is switched off. `.invalid` restores
+                // the device's own default rather than pinning it to a value we computed.
+                device.activeVideoMinFrameDuration = .invalid
+                device.activeVideoMaxFrameDuration = .invalid
+                hasRelaxedFrameRate = false
             }
-            device.activeVideoMaxFrameDuration = target
         } catch {
             // Genuinely non-fatal, so it must NOT reach `errorMessage`: `FaceUnlockCoordinator.runScanCycle` aborts the
             // whole scan on any non-nil `errorMessage`, so reporting a failed frame-rate hint there would disable face
@@ -204,6 +223,9 @@ final class CameraManager: NSObject {
             frameRateNote = "Couldn't set the camera's low-light frame rate: \(error.localizedDescription)"
         }
     }
+
+    /// Whether we relaxed this device's frame-rate window, so the off path knows there is something to undo.
+    private var hasRelaxedFrameRate = false
 
     fileprivate func publish(frame: CameraFrame) {
         currentFrame = frame
@@ -279,7 +301,15 @@ final class CameraManager: NSObject {
             guard let cgImage = ciContext.createCGImage(enhanced, from: enhanced.extent) else { return }
             // Second render only in a dark room: the bezel deny cue reads this, and gain applied to a dark frame can
             // invent or erase the rectangle edges it keys on (LivenessFeatures.swift feeds it the working frame).
-            let rawCGImage = isEnhanced ? (ciContext.createCGImage(ciImage, from: ciImage.extent) ?? cgImage) : cgImage
+            let rawCGImage: CGImage
+            if isEnhanced {
+                // Drop the frame rather than fall back to the enhanced one. The liveness deny cues trust `rawImage` to
+                // be ungained, and a transient render failure must not quietly let our own gain move a spoof decision.
+                guard let raw = ciContext.createCGImage(ciImage, from: ciImage.extent) else { return }
+                rawCGImage = raw
+            } else {
+                rawCGImage = cgImage
+            }
 
             nextFrameID &+= 1
             let frame = CameraFrame(

--- a/glance/FaceLabController.swift
+++ b/glance/FaceLabController.swift
@@ -157,7 +157,8 @@ final class FaceLabController {
             let (result, livenessFrame) = try await Task.detached(priority: .userInitiated) {
                 let result = try pipeline.recognize(in: cameraFrame.image)
                 let faceCrop = CameraManager.renderCrop(from: cameraFrame, imageRect: result.face.boundingBox)
-                return (result, LivenessFeatureExtractor.extract(from: result, frame: cameraFrame.image, faceCrop: faceCrop))
+                // `rawImage`, matching FaceUnlockCoordinator — Face Lab exists to show the real cue values.
+                return (result, LivenessFeatureExtractor.extract(from: result, frame: cameraFrame.rawImage, faceCrop: faceCrop))
             }.value
             detectedFaces = [result.face]
             currentResult = result

--- a/glance/FaceLabController.swift
+++ b/glance/FaceLabController.swift
@@ -177,7 +177,18 @@ final class FaceLabController {
 
     // MARK: - Enrollment
 
+    /// Mirrors the guided-enrollment guard in `OnboardingController`: a template built from a gained-up frame matches
+    /// neither daylight nor the flood-lit scan the same room later produces. Face Lab is a debug tool, but it writes to
+    /// the same store, so it must not be the back door around that rule.
+    var isTooDarkToEnroll: Bool {
+        camera.currentFrame?.isLowLightEnhanced ?? false
+    }
+
     func captureSample() {
+        guard !isTooDarkToEnroll else {
+            log("Too dark — the frame is being brightened by Night Boost, so this sample would poison the template.")
+            return
+        }
         guard let result = currentResult else {
             log("No face detected — can't capture a sample.")
             return

--- a/glance/FaceLabView.swift
+++ b/glance/FaceLabView.swift
@@ -400,7 +400,7 @@ struct FaceLabView: View {
                     Button("Capture Sample") {
                         controller.captureSample()
                     }
-                    .disabled(controller.currentResult == nil || controller.store.isLocked)
+                    .disabled(controller.currentResult == nil || controller.store.isLocked || controller.isTooDarkToEnroll)
                 }
 
                 if controller.store.identities.isEmpty {

--- a/glance/FaceUnlockCoordinator.swift
+++ b/glance/FaceUnlockCoordinator.swift
@@ -158,6 +158,7 @@ final class FaceUnlockCoordinator {
         scanGeneration &+= 1
         autoRetryTask?.cancel()
         autoRetryTask = nil
+        SceneIlluminator.shared.end()
         camera.stop()
         NotchOverlayController.shared.disarm()
         // Covers isEnabled being switched off directly, keeping "disarmed" and "not listening for space" in lockstep.
@@ -234,6 +235,11 @@ final class FaceUnlockCoordinator {
     /// of itself. This was a real bug — a superseded `camera.stop()` queued behind the newer cycle's `startRunning()` made the
     /// camera visibly switch on then die mid-warm-up, leaving the surviving cycle polling a dead session and never unlocking.
     private func runScanCycle(generation: Int) async {
+        // Released here rather than on the success path alone: this function has four exits, and the flood light is a
+        // global side effect (display brightness pinned, a panel over the lock screen). The generation test keeps the
+        // intended "a newer cycle owns it now" hand-off — that cycle's own defer releases it.
+        defer { if generation == scanGeneration { SceneIlluminator.shared.end() } }
+
         guard LockMonitor.isScreenActuallyLocked() else { return }
 
         await camera.start()
@@ -257,6 +263,7 @@ final class FaceUnlockCoordinator {
         )
 
         // A newer cycle now owns the camera and overlay — leave both alone, and leave the auto-retry one-shot unspent.
+        // The illuminator is handed over the same way, by the generation test in this function's `defer`.
         guard generation == scanGeneration else { return }
 
         camera.stop()
@@ -340,6 +347,8 @@ final class FaceUnlockCoordinator {
         var lastFaceBoundingBox: CGRect?
         /// Cheap way to detect "no new camera frame yet" vs. "fresh frame" — without it a repeat frame would corrupt the liveness motion signal.
         var lastProcessedFrameID: UInt64?
+        /// One-shot per cycle: once the light is on, every later frame reads bright, so this can't be re-derived per frame.
+        var hasEngagedNightBoost = false
 
         while Date() < deadline, !Task.isCancelled,
               !requireOverlayScanning || NotchOverlayController.shared.phase == .scanning {
@@ -352,12 +361,34 @@ final class FaceUnlockCoordinator {
             }
             lastProcessedFrameID = frame.id
 
+            // Night boost: the first dark frame of a cycle switches the display into a flood light for the rest of it.
+            // Judged on the raw luma, not the enhanced frame, and independent of animation settings — it's functional,
+            // not decorative. The screen must be the one the camera faces, or the light lands behind the user.
+            if !hasEngagedNightBoost,
+               GlanceSettings.shared.nightBoostEnabled,
+               frame.meanLuminance < LowLightEnhancer.darknessThreshold,
+               let screen = CameraDeviceCatalog.screenForActiveCamera() {
+                hasEngagedNightBoost = true
+                SceneIlluminator.shared.begin(on: screen)
+                statusMessage = "Dark room — lighting up the screen…"
+            }
+
+            // Frames captured while the light ramps are bad evidence for both halves: over-exposed highlights read as
+            // screen glare to the deny cue, and a half-lit face scores below threshold, which would otherwise burn
+            // through the six-frame wrong-face streak in ~0.4s at 15fps. Skip them outright rather than judge them.
+            if SceneIlluminator.shared.isSettling {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                continue
+            }
+
             let pipeline = self.pipeline
             let previousBoundingBox = lastFaceBoundingBox
             let outcome = await Task.detached(priority: .userInitiated) { () -> (FaceRecognitionResult, LivenessFrame)? in
                 guard let result = try? pipeline.recognize(in: frame.image, preferNear: previousBoundingBox) else { return nil }
                 let faceCrop = CameraManager.renderCrop(from: frame, imageRect: result.face.boundingBox)
-                return (result, LivenessFeatureExtractor.extract(from: result, frame: frame.image, faceCrop: faceCrop))
+                // Recognition gets the brightened frame; the deny cues get what the sensor actually saw, so our own
+                // gain can neither manufacture nor erase the rectangle a spoofed phone bezel would show.
+                return (result, LivenessFeatureExtractor.extract(from: result, frame: frame.rawImage, faceCrop: faceCrop))
             }.value
 
             guard let (result, livenessFrame) = outcome else {

--- a/glance/NightBoost/DisplayBrightnessControl.swift
+++ b/glance/NightBoost/DisplayBrightnessControl.swift
@@ -1,0 +1,56 @@
+//
+//  DisplayBrightnessControl.swift
+//  glance
+//
+//  Private, undocumented DisplayServices API — macOS has no public way for an app to set display brightness (unlike
+//  iOS's UIScreen.brightness). Same posture as NotchSkyLight: dlopen'd at runtime, `shared` is nil if any symbol is
+//  missing, and callers degrade to "no brightness boost" rather than crash. Verified to resolve on macOS 26.6 / Apple silicon.
+//
+
+import Foundation
+import CoreGraphics
+
+final class DisplayBrightnessControl {
+    static let shared: DisplayBrightnessControl? = DisplayBrightnessControl()
+
+    private typealias F_GetBrightness = @convention(c) (CGDirectDisplayID, UnsafeMutablePointer<Float>) -> Int32
+    private typealias F_SetBrightness = @convention(c) (CGDirectDisplayID, Float) -> Int32
+    private typealias F_CanChangeBrightness = @convention(c) (CGDirectDisplayID) -> Bool
+
+    private let getBrightness: F_GetBrightness
+    private let setBrightness: F_SetBrightness
+    private let canChangeBrightness: F_CanChangeBrightness
+
+    private init?() {
+        guard let handle = dlopen(
+            "/System/Library/PrivateFrameworks/DisplayServices.framework/Versions/A/DisplayServices",
+            RTLD_NOW
+        ) else { return nil }
+        guard
+            let getSym = dlsym(handle, "DisplayServicesGetBrightness"),
+            let setSym = dlsym(handle, "DisplayServicesSetBrightness"),
+            let canSym = dlsym(handle, "DisplayServicesCanChangeBrightness")
+        else { return nil }
+        getBrightness = unsafeBitCast(getSym, to: F_GetBrightness.self)
+        setBrightness = unsafeBitCast(setSym, to: F_SetBrightness.self)
+        canChangeBrightness = unsafeBitCast(canSym, to: F_CanChangeBrightness.self)
+    }
+
+    /// False for displays without software brightness (most external monitors) — a boost there is a no-op by design.
+    func canChange(_ display: CGDirectDisplayID) -> Bool {
+        canChangeBrightness(display)
+    }
+
+    /// 0…1, or nil if the display doesn't report.
+    func brightness(of display: CGDirectDisplayID) -> Float? {
+        var value: Float = 0
+        guard getBrightness(display, &value) == 0 else { return nil }
+        return value
+    }
+
+    /// Returns false if the display refused. Clamped to 0…1.
+    @discardableResult
+    func set(_ brightness: Float, on display: CGDirectDisplayID) -> Bool {
+        setBrightness(display, min(max(brightness, 0), 1)) == 0
+    }
+}

--- a/glance/NightBoost/IlluminationPanel.swift
+++ b/glance/NightBoost/IlluminationPanel.swift
@@ -1,0 +1,44 @@
+//
+//  IlluminationPanel.swift
+//  glance
+//
+//  The "flood light": a borderless, click-through panel that paints the upper part of the screen a warm near-white while
+//  a dark-room scan runs. Warm rather than pure white on purpose — the glare deny cue only counts near-*grey* highlights
+//  (luma ≥ 235 AND |Cb-128|, |Cr-128| ≤ 10 — GlareCueExtractor.swift:12-13), so a warm reflection off glasses or a
+//  forehead stays chromatic and is not mistaken for the screen glare that betrays a spoof.
+//
+//  The failure this avoids is a false DENY of a live user, not a false accept: a tripped glare cue latches for the whole
+//  scan (LivenessCues.swift:173,227), so one bright reflection would reject a real face for all 5 seconds.
+//
+
+import AppKit
+
+final class IlluminationPanel: NSPanel {
+    /// Warm white, roughly 3000K. Measured against `GlareCueExtractor` with a 2%-of-crop highlight: pure white denies at
+    /// 1.0x reflection gain (i.e. always), this colour not until 1.60x — the point where all three channels finally clip
+    /// to neutral. Warmer still keeps buying headroom (0.75/0.45 reaches 2.05x) but casts far enough off-white to risk
+    /// costing ArcFace similarity against a daylight-enrolled template, which is the same annoyance from the other side.
+    static let lightColor = NSColor(srgbRed: 1.0, green: 0.84, blue: 0.58, alpha: 1.0)
+
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        isOpaque = false
+        backgroundColor = Self.lightColor
+        hasShadow = false
+        isMovable = false
+        isReleasedWhenClosed = false
+        ignoresMouseEvents = true
+        alphaValue = 0
+        // One below the notch panel (.mainMenu + 3) so the scan animation stays on top of the light.
+        level = .mainMenu + 2
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}

--- a/glance/NightBoost/LowLightEnhancer.swift
+++ b/glance/NightBoost/LowLightEnhancer.swift
@@ -1,0 +1,54 @@
+//
+//  LowLightEnhancer.swift
+//  glance
+//
+//  Software gain for dark frames: denoise, then push exposure toward a mid-grey target, then lift shadows. Applied to the
+//  640px working frame only (what Vision and ArcFace see), never to the native-resolution crop the glare cue reads — a
+//  brightened crop would push highlights to near-white and trip the specular-glare deny cue on a perfectly live face.
+//
+
+import CoreImage
+import CoreGraphics
+
+nonisolated enum LowLightEnhancer {
+    /// Mirror of `GlanceSettings.nightBoostEnabled`, written on the main actor and read from the capture session queue
+    /// — same deliberate, benign race as `FaceRecognitionPipeline.minimumProminentFaceWidth`.
+    nonisolated(unsafe) static var isEnabled = true
+
+    /// Mean luma below which a frame counts as "dark". The FaceTime camera's auto-exposure lifts a dim room to roughly
+    /// 0.05–0.15 (noisy); a normally lit room sits at 0.3+. Shared by the frame enhancer and `SceneIlluminator`.
+    static let darknessThreshold: Float = 0.16
+
+    /// Exposure target, set *pre*-gamma: the shadow lift that runs after `CIExposureAdjust` adds roughly another 20%,
+    /// so 0.33 here lands a finished frame near 0.40 mean luma. Mid-grey rather than 0.5 so highlights stay unblown —
+    /// a blown highlight is what the glare deny cue reads as a spoof.
+    private static let targetLuminance: Float = 0.33
+    /// +4 EV is a 16x linear gain. Denoising runs first, which is what makes this survivable; past this the sensor's
+    /// own noise floor is all that's left to amplify.
+    private static let maxExposureBoost: Float = 4.0
+
+    /// `SceneLuminance` reports a gamma-encoded (display-space) value, but `CIExposureAdjust` multiplies *linear*
+    /// radiance. Taking the ratio in display space silently under-corrects, and worst in the darkest rooms where the
+    /// curve is steepest — so both ends of the ratio are linearised first.
+    private static func srgbToLinear(_ channel: Float) -> Float {
+        channel <= 0.04045 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+    }
+
+    /// Returns the same image untouched when the scene is not dark or the feature is off.
+    static func enhance(_ image: CIImage, meanLuminance: Float) -> CIImage {
+        guard isEnabled, meanLuminance < darknessThreshold else { return image }
+        let extent = image.extent
+        let linearMean = max(srgbToLinear(meanLuminance), 0.0002)
+        let ev = min(maxExposureBoost, max(0, log2(srgbToLinear(targetLuminance) / linearMean)))
+
+        // Denoise *before* gain — the reduction filter's threshold is absolute, so amplified noise would sail past it.
+        var output = image.applyingFilter("CINoiseReduction", parameters: [
+            "inputNoiseLevel": 0.03,
+            "inputSharpness": 0.4,
+        ])
+        output = output.applyingFilter("CIExposureAdjust", parameters: ["inputEV": ev])
+        // Gamma < 1 lifts shadows without touching white — where the eyes and nostrils ArcFace keys on hide in a dark frame.
+        output = output.applyingFilter("CIGammaAdjust", parameters: ["inputPower": 0.8])
+        return output.cropped(to: extent)
+    }
+}

--- a/glance/NightBoost/SceneIlluminator.swift
+++ b/glance/NightBoost/SceneIlluminator.swift
@@ -1,0 +1,171 @@
+//
+//  SceneIlluminator.swift
+//  glance
+//
+//  Turns the Mac's own display into the flood illuminator Face ID gets from hardware: for the duration of a dark-room
+//  scan, drives the target display to full brightness and shows a warm panel over its upper part (the password field in
+//  the lower third stays clear). Everything is restored on `end()`, which is idempotent and is called from every scan
+//  exit path plus disarm — the worst case of a crash mid-scan is a screen left bright, never a stuck panel.
+//
+//  Lock-screen visibility uses the same SkyLight delegation as the notch (see NotchSkyLight.swift); without it the panel
+//  is simply invisible while locked and only the brightness boost applies.
+//
+
+import AppKit
+
+@MainActor
+final class SceneIlluminator {
+    static let shared = SceneIlluminator()
+
+    /// How much of the screen height, measured from the top, the light panel covers. Deliberately the top third only:
+    /// loginwindow draws the avatar and password field around the vertical middle, and a panel over that would hide the
+    /// manual fallback exactly when face unlock is struggling. The top band is also nearest the camera, so it is the
+    /// most useful third to light anyway.
+    static let coverageFraction: CGFloat = 0.38
+    /// Not fully opaque so the wallpaper still ghosts through and it reads as "a light came on", not "the screen broke".
+    static let panelAlpha: CGFloat = 0.88
+    /// The Mac's camera exposes no controllable exposure mode (every `isExposureModeSupported` is false), so the ISP's
+    /// own auto-exposure is the only thing tracking this light. Fading in slowly enough for it to follow is what keeps
+    /// highlights from railing to neutral white and tripping the glare deny cue — see `IlluminationPanel.lightColor`.
+    static let fadeInDuration: TimeInterval = 0.8
+    static let fadeOutDuration: TimeInterval = 0.20
+    /// Fade plus a margin for auto-exposure to converge. Frames inside this window are skipped by the scan loop rather
+    /// than judged, since a half-lit frame is bad evidence for both recognition and liveness.
+    static let settleDuration: Duration = .milliseconds(1300)
+    /// Brightness during a scan. Not 1.0: the point is enough light to expose a face, and the last stop mostly buys
+    /// blown specular highlights off glasses, which is precisely what the glare deny cue rejects as a spoof.
+    private static let boostedBrightness: Float = 0.9
+
+    private(set) var isActive = false
+    /// When the light was switched on, for `isSettling`.
+    private var litAt: ContinuousClock.Instant?
+
+    /// True while the light is still coming up and exposure has not caught up. The scan loop skips these frames.
+    var isSettling: Bool {
+        guard isActive, let litAt else { return false }
+        return ContinuousClock.now - litAt < Self.settleDuration
+    }
+
+    private var panel: IlluminationPanel?
+    private var isSkyLightDelegated = false
+    /// Display + brightness as found at `begin`, restored verbatim at `end`.
+    private var restoreBrightness: (display: CGDirectDisplayID, value: Float)?
+
+    private init() {
+        // A quit mid-scan (menu bar Quit, a Sparkle update relaunch, logout) would otherwise leave the display pinned at
+        // full brightness with no app left to restore it. `willTerminate` is delivered on the main thread before exit.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated { SceneIlluminator.shared.restoreImmediately() }
+        }
+    }
+
+    /// Synchronous teardown for paths that have no time for a fade — app termination. Ordinary scan exits use `end()`.
+    func restoreImmediately() {
+        guard isActive else { return }
+        isActive = false
+        litAt = nil
+        if let panel {
+            if isSkyLightDelegated, let skyLight = NotchSkyLight.shared {
+                skyLight.undelegate(panel)
+            }
+            isSkyLightDelegated = false
+            panel.orderOut(nil)
+        }
+        restoreBrightnessIfNeeded()
+    }
+
+    /// No-op if already lit. `screen` is where the light goes — normally the display the camera lives on.
+    func begin(on screen: NSScreen) {
+        guard !isActive else { return }
+        isActive = true
+        litAt = .now
+
+        boostBrightness(of: screen)
+        showPanel(on: screen)
+    }
+
+    /// Safe to call any number of times, from any exit path.
+    func end() {
+        guard isActive else { return }
+        isActive = false
+        litAt = nil
+
+        hidePanel()
+        restoreBrightnessIfNeeded()
+    }
+
+    // MARK: - Brightness
+
+    private func boostBrightness(of screen: NSScreen) {
+        guard let control = DisplayBrightnessControl.shared,
+              let display = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+              control.canChange(display),
+              let current = control.brightness(of: display)
+        else { return }
+        // Only remember a value we will actually change, so `end` never "restores" a brightness the user set themselves.
+        guard current < Self.boostedBrightness else { return }
+        restoreBrightness = (display, current)
+        control.set(Self.boostedBrightness, on: display)
+    }
+
+    /// The record is cleared only once the write is confirmed. Clearing first would make a single refused restore
+    /// permanent — the app would have forgotten the brightness the user actually had.
+    private func restoreBrightnessIfNeeded() {
+        guard let pending = restoreBrightness else { return }
+        guard let control = DisplayBrightnessControl.shared, control.canChange(pending.display) else { return }
+        if control.set(pending.value, on: pending.display) {
+            restoreBrightness = nil
+        }
+    }
+
+    // MARK: - Panel
+
+    private func showPanel(on screen: NSScreen) {
+        let frame = screen.frame
+        let height = (frame.height * Self.coverageFraction).rounded()
+        let rect = NSRect(x: frame.minX, y: frame.maxY - height, width: frame.width, height: height)
+
+        let panel: IlluminationPanel
+        if let existing = self.panel {
+            panel = existing
+            panel.setFrame(rect, display: false)
+        } else {
+            panel = IlluminationPanel(contentRect: rect)
+            self.panel = panel
+        }
+
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        if LockMonitor.isScreenActuallyLocked(), let skyLight = NotchSkyLight.shared {
+            skyLight.delegate(panel)
+            isSkyLightDelegated = true
+        }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = Self.fadeInDuration
+            panel.animator().alphaValue = Self.panelAlpha
+        }
+    }
+
+    private func hidePanel() {
+        guard let panel else { return }
+        let wasDelegated = isSkyLightDelegated
+        isSkyLightDelegated = false
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = Self.fadeOutDuration
+            panel.animator().alphaValue = 0
+        }, completionHandler: {
+            Task { @MainActor in
+                // A `begin` may have raced in during the fade — leave its panel alone.
+                guard !self.isActive else { return }
+                if wasDelegated, let skyLight = NotchSkyLight.shared {
+                    skyLight.undelegate(panel)
+                }
+                panel.orderOut(nil)
+            }
+        })
+    }
+}

--- a/glance/NightBoost/SceneIlluminator.swift
+++ b/glance/NightBoost/SceneIlluminator.swift
@@ -50,6 +50,11 @@ final class SceneIlluminator {
     private var isSkyLightDelegated = false
     /// Display + brightness as found at `begin`, restored verbatim at `end`.
     private var restoreBrightness: (display: CGDirectDisplayID, value: Float)?
+    /// Retries a refused restore without needing another scan to come along. Bounded, so a permanently unwritable
+    /// display costs a couple of seconds of attempts rather than a task that never ends.
+    private var restoreRetryTask: Task<Void, Never>?
+    private static let restoreRetryAttempts = 6
+    private static let restoreRetryDelay: Duration = .milliseconds(400)
 
     private init() {
         // A quit mid-scan (menu bar Quit, a Sparkle update relaunch, logout) would otherwise leave the display pinned at
@@ -65,17 +70,20 @@ final class SceneIlluminator {
 
     /// Synchronous teardown for paths that have no time for a fade — app termination. Ordinary scan exits use `end()`.
     func restoreImmediately() {
-        guard isActive else { return }
-        isActive = false
-        litAt = nil
-        if let panel {
-            if isSkyLightDelegated, let skyLight = NotchSkyLight.shared {
-                skyLight.undelegate(panel)
+        if isActive {
+            isActive = false
+            litAt = nil
+            if let panel {
+                if isSkyLightDelegated, let skyLight = NotchSkyLight.shared {
+                    skyLight.undelegate(panel)
+                }
+                isSkyLightDelegated = false
+                panel.orderOut(nil)
             }
-            isSkyLightDelegated = false
-            panel.orderOut(nil)
         }
-        restoreBrightnessIfNeeded()
+        // One synchronous attempt and no retry task: the process is going away, so there is nothing left to run it.
+        restoreRetryTask?.cancel()
+        attemptBrightnessRestore()
     }
 
     /// No-op if already lit. `screen` is where the light goes — normally the display the camera lives on.
@@ -90,11 +98,13 @@ final class SceneIlluminator {
 
     /// Safe to call any number of times, from any exit path.
     func end() {
-        guard isActive else { return }
-        isActive = false
-        litAt = nil
-
-        hidePanel()
+        if isActive {
+            isActive = false
+            litAt = nil
+            hidePanel()
+        }
+        // Outside the `isActive` branch on purpose: a restore refused by a previous scan is still owed, and every
+        // caller of this method guards on `isActive`, so gating the retry on it would strand the display forever.
         restoreBrightnessIfNeeded()
     }
 
@@ -107,19 +117,42 @@ final class SceneIlluminator {
               let current = control.brightness(of: display)
         else { return }
         // Only remember a value we will actually change, so `end` never "restores" a brightness the user set themselves.
+        // Flush anything a previous scan still owes before recording a new baseline, and refuse to boost again while
+        // that is unresolved: `current` would be our own boosted value, so recording it would make the display's
+        // brightness permanently ours.
+        restoreRetryTask?.cancel()
+        attemptBrightnessRestore()
+        guard restoreBrightness == nil else { return }
+
         guard current < Self.boostedBrightness else { return }
         restoreBrightness = (display, current)
         control.set(Self.boostedBrightness, on: display)
     }
 
+    /// Attempts the restore, keeping the record if it is refused, and schedules a bounded retry when it is.
+    private func restoreBrightnessIfNeeded() {
+        guard restoreBrightness != nil else { return }
+        guard !attemptBrightnessRestore() else { return }
+
+        restoreRetryTask?.cancel()
+        restoreRetryTask = Task { [weak self] in
+            for _ in 0..<Self.restoreRetryAttempts {
+                try? await Task.sleep(for: Self.restoreRetryDelay)
+                guard !Task.isCancelled, let self, self.restoreBrightness != nil else { return }
+                if self.attemptBrightnessRestore() { return }
+            }
+        }
+    }
+
     /// The record is cleared only once the write is confirmed. Clearing first would make a single refused restore
     /// permanent — the app would have forgotten the brightness the user actually had.
-    private func restoreBrightnessIfNeeded() {
-        guard let pending = restoreBrightness else { return }
-        guard let control = DisplayBrightnessControl.shared, control.canChange(pending.display) else { return }
-        if control.set(pending.value, on: pending.display) {
-            restoreBrightness = nil
-        }
+    @discardableResult
+    private func attemptBrightnessRestore() -> Bool {
+        guard let pending = restoreBrightness else { return true }
+        guard let control = DisplayBrightnessControl.shared, control.canChange(pending.display) else { return false }
+        guard control.set(pending.value, on: pending.display) else { return false }
+        restoreBrightness = nil
+        return true
     }
 
     // MARK: - Panel

--- a/glance/NightBoost/SceneLuminance.swift
+++ b/glance/NightBoost/SceneLuminance.swift
@@ -1,0 +1,38 @@
+//
+//  SceneLuminance.swift
+//  glance
+//
+//  Cheap "how dark is the room" estimate for a camera frame — a single CIAreaAverage reduction over the working frame.
+//  Runs on the capture session queue alongside frame conversion, so it costs one small GPU pass per frame.
+//
+
+import CoreImage
+import CoreGraphics
+
+nonisolated enum SceneLuminance {
+    /// Rec. 709 luma of the frame's average colour, 0 (black) … 1 (white). `nil` if Core Image couldn't reduce the image.
+    /// The webcam's own auto-exposure already gains up dark scenes, so a genuinely dark room still lands well under
+    /// `LowLightEnhancer.darknessThreshold` — but with heavy noise, which is what the enhancer and illuminator address.
+    static func meanLuminance(of image: CIImage, context: CIContext) -> Float? {
+        let extent = image.extent
+        guard !extent.isEmpty, !extent.isInfinite else { return nil }
+        guard let averaged = CIFilter(
+            name: "CIAreaAverage",
+            parameters: [kCIInputImageKey: image, kCIInputExtentKey: CIVector(cgRect: extent)]
+        )?.outputImage else { return nil }
+
+        var pixel = [UInt8](repeating: 0, count: 4)
+        context.render(
+            averaged,
+            toBitmap: &pixel,
+            rowBytes: 4,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            format: .RGBA8,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
+        )
+        let r = Float(pixel[0]) / 255
+        let g = Float(pixel[1]) / 255
+        let b = Float(pixel[2]) / 255
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    }
+}

--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -384,6 +384,10 @@ final class OnboardingController {
     /// Whether the last-seen face read as too small to enroll reliably — swaps the pose
     /// instruction for a "move closer" prompt while true.
     private(set) var isTooFar = false
+    /// Set when the room is dark enough that Night Boost is gaining frames up. Enrolling from those would bake a
+    /// noisy, under-exposed face into the template, which then matches neither daylight nor the flood-lit scan the
+    /// unlock path produces in the same room.
+    private(set) var isTooDark = false
     private(set) var enrollmentComplete = false
 
     /// Sectors already captured — read by EnrollmentRingView to decide which
@@ -433,6 +437,7 @@ final class OnboardingController {
     /// completion line.
     var enrollmentInstruction: String {
         if enrollmentComplete { return "Face captured" }
+        if isTooDark { return "Too dark to set up — turn on a light" }
         if isTooFar { return "Bring your face closer" }
         return currentPose?.instruction ?? ""
     }
@@ -451,7 +456,7 @@ final class OnboardingController {
     /// Live head direction, or `nil` when there's nothing to point at. Axes are normalized
     /// against the current pose's thresholds, so `progress` hits 1 as the pose starts matching.
     var headTurn: HeadTurn? {
-        guard step == .enroll, !enrollmentComplete, faceDetected, !isTooFar,
+        guard step == .enroll, !enrollmentComplete, faceDetected, !isTooFar, !isTooDark,
               let pose = currentPose, pose != .center,
               let yaw = currentYaw, let pitch = currentPitch else { return nil }
 
@@ -704,6 +709,14 @@ final class OnboardingController {
               let cameraFrame = camera.currentFrame, let pose = currentPose else { return }
         isProcessingFrame = true
         defer { isProcessingFrame = false }
+
+        guard !cameraFrame.isLowLightEnhanced else {
+            isTooDark = true
+            matchStreak = 0
+            poseHoldStartedAt = nil
+            return
+        }
+        isTooDark = false
 
         let pipeline = self.pipeline
         let minimumWidth = enrollmentMinimumFaceWidth

--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -617,6 +617,7 @@ final class OnboardingController {
         matchStreak = 0
         poseHoldStartedAt = nil
         isTooFar = false
+        isTooDark = false
         enrollmentComplete = false
         guideVisible = false
         cameraPreviewVisible = true
@@ -629,6 +630,9 @@ final class OnboardingController {
         guideVisible = true
         cameraPreviewVisible = true
         showCheckmark = false
+        // Stale from a previous dark attempt would otherwise show "Too dark" and suppress head-turn feedback before
+        // the restarted camera has produced a single frame to judge.
+        isTooDark = false
         poseStartedAt = .now
         captureReadyAt = .now + initialCaptureDelay
         poseHoldStartedAt = nil

--- a/glance/Settings/GlanceSettings.swift
+++ b/glance/Settings/GlanceSettings.swift
@@ -104,6 +104,7 @@ final class GlanceSettings {
         static let faceDetectionSeconds = "GlanceSettings.faceDetectionSeconds"
         static let autoRetryOnce = "GlanceSettings.autoRetryOnce"
         static let hapticFeedbackEnabled = "GlanceSettings.hapticFeedbackEnabled"
+        static let nightBoostEnabled = "GlanceSettings.nightBoostEnabled"
         static let preferredDisplayID = "GlanceSettings.preferredDisplayID"
         static let preferredDisplayName = "GlanceSettings.preferredDisplayName"
         static let autoLockIntervalDays = "GlanceSettings.autoLockIntervalDays"
@@ -197,6 +198,15 @@ final class GlanceSettings {
     /// see `NotchOverlayView`'s hover handler and `.onChange(of: controller.phase)`.
     var hapticFeedbackEnabled: Bool {
         didSet { defaults.set(hapticFeedbackEnabled, forKey: Key.hapticFeedbackEnabled) }
+    }
+    /// Dark-room help: brighten frames before recognition, let the camera slow to 15 fps for a longer exposure, and
+    /// light the display up during the scan — see the `NightBoost` folder. Mirrored into `LowLightEnhancer.isEnabled`
+    /// since the frame path reads it off the main actor.
+    var nightBoostEnabled: Bool {
+        didSet {
+            defaults.set(nightBoostEnabled, forKey: Key.nightBoostEnabled)
+            LowLightEnhancer.isEnabled = nightBoostEnabled
+        }
     }
 
     static let faceDetectionRange = 3...10
@@ -301,6 +311,7 @@ final class GlanceSettings {
             ?? 5
         autoRetryOnce = defaults.object(forKey: Key.autoRetryOnce) as? Bool ?? false
         hapticFeedbackEnabled = defaults.object(forKey: Key.hapticFeedbackEnabled) as? Bool ?? true
+        nightBoostEnabled = defaults.object(forKey: Key.nightBoostEnabled) as? Bool ?? true
         preferredDisplayID = defaults.string(forKey: Key.preferredDisplayID)
         preferredDisplayName = defaults.string(forKey: Key.preferredDisplayName)
 
@@ -320,5 +331,6 @@ final class GlanceSettings {
         // Push into the nonisolated mirror immediately, or FaceRecognitionPipeline
         // would keep its own default until the slider is first touched.
         FaceRecognitionPipeline.minimumProminentFaceWidth = minimumFaceWidth
+        LowLightEnhancer.isEnabled = nightBoostEnabled
     }
 }

--- a/glance/Settings/Pages/CameraSettingsPage.swift
+++ b/glance/Settings/Pages/CameraSettingsPage.swift
@@ -85,6 +85,9 @@ struct CameraSettingsPage: View {
                         .strokeBorder(SettingsMetrics.rowBorder, lineWidth: SettingsMetrics.rowBorderWidth)
                 )
 
+            if isPreviewShown, let note = previewCamera.frameRateNote {
+                SettingsCaption(text: note)
+            }
             if isPreviewShown, let error = previewCamera.errorMessage {
                 SettingsCaption(text: error)
             }

--- a/glance/Settings/Pages/GeneralSettingsPage.swift
+++ b/glance/Settings/Pages/GeneralSettingsPage.swift
@@ -111,6 +111,16 @@ struct GeneralSettingsPage: View {
         }
 
         VStack(alignment: .leading, spacing: 8) {
+            SettingsSectionTitle(text: "Night")
+            SettingsGroup {
+                SettingsRowContent(title: "Light up the screen in the dark") {
+                    GlanceToggle(isOn: $settings.nightBoostEnabled)
+                }
+            }
+            SettingsCaption(text: "When the room is dark, Glance turns the top of the display into a warm light for the length of the scan, lets the camera slow to 15 fps for a longer exposure, and brightens frames before recognition. Your brightness comes back when the scan ends.")
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
             SettingsSectionTitle(text: "Animation")
             SettingsGroup {
                 SettingsRowContent(title: "Show animation") {


### PR DESCRIPTION
The README says PRs aren't being accepted, so no hard feelings if this just sits or gets closed. Putting it up in case it's useful, and because the branch is easier to read than a description.

## What

Face unlock currently gives up in a dark room. The webcam hands ArcFace an under-exposed, noisy face and the scan times out. A MacBook has no IR flood illuminator, so the only light available is the display.

Night Boost uses it, in three layers behind one setting (General → Night, on by default):

- **Measure** — `SceneLuminance` takes each working frame's mean luma with one `CIAreaAverage` pass. Below 0.16 counts as dark.
- **Gain** — `LowLightEnhancer` denoises, pushes exposure toward a mid-grey target and lifts shadows, before Vision and ArcFace see the frame.
- **Light** — `SceneIlluminator` puts a warm panel over the top third of the display the camera faces and raises brightness to 0.9 for the length of the scan, restoring both afterwards.

## The parts that aren't arbitrary

Most of the constants here are answers to the liveness code, not taste.

**The panel is warm (~3000K) because of the glare deny cue.** `GlareCueExtractor` counts near-*grey* highlights, so a white flood light would deny a live face instantly. Measured against the real extractor with a 2%-of-crop highlight, pure white denies at 1.0x reflection gain and this colour not until 1.60x. Brightness stops at 0.9 for the same reason — the last stop mostly buys blown specular highlights off glasses.

**Coverage is the top 38%.** loginwindow draws the password field near the vertical middle, and covering that would hide the manual fallback exactly when face unlock is struggling.

**Frames during the ramp are skipped, not judged.** The Mac camera reports no supported exposure mode, so the ISP's own auto-exposure is the only thing tracking the light. The panel fades in over 0.8s and a 1.3s settle window is skipped: a half-lit frame is bad evidence for both halves, and at 15fps six over-exposed frames would burn through `wrongFaceStreakThreshold` in about 0.4s.

**Deny cues read a new `CameraFrame.rawImage`.** That's the ungained working frame, so the gain can't manufacture or erase the rectangle a spoofed phone bezel would show. Recognition keeps the enhanced frame. Face Lab was updated to match so it still reports real cue values.

**The exposure gain is computed in linear space.** `CIExposureAdjust` multiplies linear radiance but the measured luma is gamma-encoded, and doing the ratio in display space under-corrects worst in the darkest rooms. Measured through the real filter chain, a dim frame lands at 0.42 mean instead of 0.25.

**`activeVideoMaxFrameDuration` is relaxed to 1/15s** so the ISP may double its exposure, and reset to `.invalid` when the setting is off so the device returns to its own default rather than being pinned at whatever value we computed. It re-applies on every `start()`, since setting `activeFormat` resets it and `reconcileDeviceIfNeeded` early-returns on an unchanged device. Its failure is advisory and deliberately never touches `errorMessage`, which `runScanCycle` treats as a fatal scan abort.

**Enrollment refuses a gained-up frame** ("Too dark to set up") instead of silently storing a template that matches neither daylight nor the flood-lit scan the same room later produces.

`DisplayBrightnessControl` dlopens the private DisplayServices framework, same posture as `NotchSkyLight`: nil singleton on failure, callers degrade to no brightness boost. Brightness is restored on every scan exit through a generation-checked `defer`, and on app termination.

## Measured, on an M1 Pro / macOS 26.6.2

| | |
|---|---|
| Brightness round trip | 0.496 → 0.9 → 0.496 exactly, on both the normal exit and the quit path |
| Frame rate | max moves to 15fps and back to 30fps with the toggle |
| Glare headroom | white denies at 1.0x reflection gain, this panel at 1.60x |
| Bezel detection on gained frames | unchanged, still 1.00 confidence |
| Cost | 0.4ms per frame added, about 1% of the 33ms budget |

## What I haven't verified

I haven't run this as the installed app against a real lock screen — an unsigned dev build shares UserDefaults with a working install under the same bundle id, and I didn't want to disturb mine. Everything above was measured through harnesses against the real code and the real camera and display.

Whether ArcFace still clears 0.66 under the flood light against a daylight-enrolled template is the open question. Face Lab is the place to check it, and enrolling a second identity under the light is the fallback if it reads low.

Heads up that #17 touches `CameraDeviceCatalog.swift`, `CameraManager.swift` and `OnboardingController.swift` too, so whichever lands second will need a rebase.
