### PR TITLE
Say so when the face model fails to load

### DIFF
--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -429,21 +429,22 @@ final class OnboardingController {
         EnrollmentPose(rawValue: currentPoseIndex)
     }
 
-    /// Non-nil when the ArcFace Core ML model failed to load and `FaceRecognitionPipeline` fell back to Vision feature
-    /// prints. That fallback makes enrollment impossible rather than merely worse: `VisionFeaturePrintEmbedder` sets
+    /// Non-nil when `ArcFaceEmbedder` failed to initialise for any reason — a missing model, a Core ML load failure,
+    /// or pixel-buffer pool creation — and `FaceRecognitionPipeline` fell back to Vision feature prints. That fallback
+    /// makes enrollment impossible rather than merely worse: `VisionFeaturePrintEmbedder` sets
     /// `requiresAlignment = false`, so `recognize` returns `.paddedCrop`, and `processMatchedEnrollFrame` accepts only
     /// `.fivePoint`. Every frame is silently rejected, at every angle, in every light. Until now the only place that
     /// said so was Face Lab, which is hidden behind five clicks on the About page.
     var recognitionUnavailableReason: String? {
         guard pipeline.usingFallbackEmbedder else { return nil }
-        return pipeline.fallbackReason ?? "the face model could not be loaded"
+        return pipeline.fallbackReason ?? "face recognition is unavailable"
     }
 
     /// Copy shown under the camera: pose guidance, a closer-up prompt, or the
     /// completion line.
     var enrollmentInstruction: String {
         // First, because it is the only one of these the user cannot act their way out of.
-        if recognitionUnavailableReason != nil { return "Face model didn't load — setup can't continue" }
+        if recognitionUnavailableReason != nil { return "Face recognition unavailable — setup can't continue" }
         if enrollmentComplete { return "Face captured" }
         if isTooFar { return "Bring your face closer" }
         return currentPose?.instruction ?? ""

--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -429,9 +429,21 @@ final class OnboardingController {
         EnrollmentPose(rawValue: currentPoseIndex)
     }
 
+    /// Non-nil when the ArcFace Core ML model failed to load and `FaceRecognitionPipeline` fell back to Vision feature
+    /// prints. That fallback makes enrollment impossible rather than merely worse: `VisionFeaturePrintEmbedder` sets
+    /// `requiresAlignment = false`, so `recognize` returns `.paddedCrop`, and `processMatchedEnrollFrame` accepts only
+    /// `.fivePoint`. Every frame is silently rejected, at every angle, in every light. Until now the only place that
+    /// said so was Face Lab, which is hidden behind five clicks on the About page.
+    var recognitionUnavailableReason: String? {
+        guard pipeline.usingFallbackEmbedder else { return nil }
+        return pipeline.fallbackReason ?? "the face model could not be loaded"
+    }
+
     /// Copy shown under the camera: pose guidance, a closer-up prompt, or the
     /// completion line.
     var enrollmentInstruction: String {
+        // First, because it is the only one of these the user cannot act their way out of.
+        if recognitionUnavailableReason != nil { return "Face model didn't load — setup can't continue" }
         if enrollmentComplete { return "Face captured" }
         if isTooFar { return "Bring your face closer" }
         return currentPose?.instruction ?? ""

--- a/glance/Settings/Pages/RecognitionSettingsPage.swift
+++ b/glance/Settings/Pages/RecognitionSettingsPage.swift
@@ -56,6 +56,12 @@ struct RecognitionSettingsPage: View {
 
     private var unlockedState: some View {
         VStack(alignment: .leading, spacing: 20) {
+            // Every control below tunes a model that isn't running. Shown here rather than only in Face Lab, which is
+            // hidden behind five clicks on the About page — an affected user has no reason to know it exists.
+            if coordinator.pipeline.usingFallbackEmbedder {
+                SettingsCaption(text: "The ArcFace model didn’t load (\(coordinator.pipeline.fallbackReason ?? "unknown reason")), so glance fell back to Vision’s feature print, which is far too weak to unlock with. Face setup can’t complete and the thresholds below don’t apply. Reinstalling glance is the usual fix.")
+            }
+
             SettingsGroup {
                 SettingsSteppedSliderRowContent(
                     title: "Match confidence",

--- a/glance/Settings/Pages/RecognitionSettingsPage.swift
+++ b/glance/Settings/Pages/RecognitionSettingsPage.swift
@@ -59,7 +59,7 @@ struct RecognitionSettingsPage: View {
             // Every control below tunes a model that isn't running. Shown here rather than only in Face Lab, which is
             // hidden behind five clicks on the About page — an affected user has no reason to know it exists.
             if coordinator.pipeline.usingFallbackEmbedder {
-                SettingsCaption(text: "The ArcFace model didn’t load (\(coordinator.pipeline.fallbackReason ?? "unknown reason")), so glance fell back to Vision’s feature print, which is far too weak to unlock with. Face setup can’t complete and the thresholds below don’t apply. Reinstalling glance is the usual fix.")
+                SettingsCaption(text: "ArcFace didn’t start (\(coordinator.pipeline.fallbackReason ?? "unknown reason")), so glance fell back to Vision’s feature print — an embedder the code itself calls too thin to gate unlock on. Guided setup can’t capture a face at all, and any face enrolled while ArcFace was working won’t match, because the two produce unrelated embeddings. Reinstalling glance is the usual fix.")
             }
 
             SettingsGroup {


### PR DESCRIPTION
## The bug

If the ArcFace Core ML model fails to load for any reason, `FaceRecognitionPipeline` quietly swaps in `VisionFeaturePrintEmbedder`. For unlock that is a weak-but-working fallback. For **enrollment it is a dead end**, and nothing says so:

```
VisionFeaturePrintEmbedder.requiresAlignment = false     (FaceEmbedder.swift:45)
  -> recognize() takes the crop branch, tier = .paddedCrop   (FaceRecognitionPipeline.swift:69-81)
  -> processMatchedEnrollFrame requires .fivePoint           (OnboardingController.swift:778)
  -> guard fails, matchStreak = 0, no sample is ever captured
```

So the user sees their face detected and tracked, the ring never fills, and there is no error — at every angle, in every lighting condition. The one place that reported the fallback is Face Lab, which is hidden behind five clicks on the app icon in About. Someone hitting this has no reason to know it exists.

I want to be careful here: I can't prove this is what #6 ("no matter the angle, cannot recognize, tried all angles and lighting") is hitting, since I don't have that hardware. But it is a code path that produces exactly those symptoms with exactly that lack of feedback, and right now there is no way for a reporter to tell you whether they're in it.

## The change

Report the condition in the two places someone would actually be standing:

- **Onboarding** — "Face model didn't load — setup can't continue", instead of cycling pose hints that cannot be satisfied.
- **Recognition settings** — a line above the sliders, which otherwise tune a model that is not running.

Two files, no behaviour change beyond the messages.

## Deliberately not included

This only reports the condition. `FaceEmbedder.swift:5-6` already describes the fallback as too thin to gate unlock on, so **refusing** to unlock while it is active may be the right end state rather than warning about it. That is a policy call, so I left it to you rather than bundling it.

Also worth a look separately: nothing in `FaceUnlockCoordinator` consults `usingFallbackEmbedder`, so an affected install will happily go on typing your password based on Vision feature-print similarity.
