### PR TITLE
Fix the camera permission prompt describing a debug tab

### DIFF
--- a/glance.xcodeproj/project.pbxproj
+++ b/glance.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = glance/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_NSCameraUsageDescription = "glance uses the camera to test on-device face recognition in the Face Lab debug tab.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "glance uses the camera to recognize your face and unlock your Mac. Frames are processed on-device and are never saved.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -320,7 +320,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = glance/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_NSCameraUsageDescription = "glance uses the camera to test on-device face recognition in the Face Lab debug tab.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "glance uses the camera to recognize your face and unlock your Mac. Frames are processed on-device and are never saved.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
macOS shows `NSCameraUsageDescription` verbatim, both in the permission dialog at first launch and afterwards in System Settings → Privacy & Security → Camera. Right now it reads:

> glance uses the camera to test on-device face recognition in the Face Lab debug tab.

That was accurate when Face Lab was the camera's only consumer. It's now hidden behind five clicks on the About page, and the camera's real job is unlocking the Mac. So the very first thing a new user is asked to approve describes a debug feature they will never open.

It also skips the reassurance that belongs in exactly that sentence. The README makes a point of "Frames are processed in memory and never written to disk", but the permission prompt — the one moment the user is deciding whether to trust the app with their camera — doesn't say it.

Replaced with:

> glance uses the camera to recognize your face and unlock your Mac. Frames are processed on-device and are never saved.

Both the Debug and Release configs, since they're set separately in `project.pbxproj`. I built Release and read the string back out of the built `Info.plist` to confirm it lands.

One line each, no code change.
