### PR TITLE
Match enrollment poses the way the progress ring measures them

### DIFF
--- a/glance/Onboarding/EnrollmentPoseGeometry.swift
+++ b/glance/Onboarding/EnrollmentPoseGeometry.swift
@@ -1,0 +1,89 @@
+//
+//  EnrollmentPoseGeometry.swift
+//  glance
+//
+//  The pure geometry behind guided enrollment: turning Vision's yaw/pitch into a direction and deciding whether that
+//  direction satisfies a pose. Deliberately free of AppKit, actors and app state so `tools/enrollment_selftest.swift`
+//  can compile this exact source and test the shipping implementation rather than a copy of it.
+//
+//  Everything the progress ring shows and everything the gate accepts is derived from `Turn`, so the two cannot
+//  disagree — which they used to, by a factor of 1.41 on the diagonals.
+//
+
+import Foundation
+
+nonisolated enum EnrollmentPoseGeometry {
+    // MARK: - Bands, in radians
+
+    /// How far the head must turn on each axis before a directional pose counts. These set the unit of `Turn`.
+    static let yawInnerThreshold: Float = 0.25
+    static let pitchInnerThreshold: Float = 0.20
+    /// How still the head must be for the centre pose, which is a box around the origin rather than a direction.
+    static let yawCenterTolerance: Float = 0.18
+    static let pitchCenterTolerance: Float = 0.15
+
+    /// Eight compass sectors.
+    static let sectorWidth: Double = 45
+    /// Upper bound on a turn, replacing the old per-axis outer caps that rejected wild Vision estimates. In `Turn`
+    /// units those were yawOuterCap/yawInnerThreshold = 4.8 and pitchOuterCap/pitchInnerThreshold = 4.5; the lower
+    /// of the two keeps the stricter behaviour.
+    static let outerMagnitudeCap: Double = 4.5
+
+    // MARK: - Turn
+
+    /// A head direction, normalized so 1.0 means "turned far enough".
+    struct Turn: Equatable {
+        /// Screen-right, in units of `yawInnerThreshold`.
+        let x: Double
+        /// Up, in units of `pitchInnerThreshold`.
+        let y: Double
+
+        var magnitude: Double { (x * x + y * y).squareRoot() }
+
+        /// Compass degrees, 0 = up, clockwise — the same frame as `EnrollmentPose.compassAngle`.
+        var compassAngle: Double {
+            let degrees = atan2(x, y) * 180 / .pi
+            return degrees < 0 ? degrees + 360 : degrees
+        }
+
+        /// Beyond this the Vision estimate is not trustworthy and no pose accepts it, so nothing should render as ready.
+        var isWithinRange: Bool { magnitude <= outerMagnitudeCap }
+    }
+
+    /// Vision inverts both axes against the screen: +yaw turns left, +pitch looks down.
+    static func turn(yaw: Float, pitch: Float) -> Turn {
+        Turn(x: Double(-yaw / yawInnerThreshold), y: Double(-pitch / pitchInnerThreshold))
+    }
+
+    /// How far the head must turn, in `Turn` units. `factor` folds in per-pose leniency and the stall widening; both
+    /// make this smaller, exactly as they used to widen the rectangular bands.
+    static func requiredMagnitude(factor: Float) -> Double {
+        1.0 / Double(factor)
+    }
+
+    // MARK: - Sectors
+
+    /// Whether `angle` belongs to the sector centred on `compass`.
+    ///
+    /// Half-open, `[centre - 22.5, centre + 22.5)`. A closed test on both ends would let a turn sitting exactly on a
+    /// boundary satisfy two adjacent poses at once; a fully open one would leave that angle owned by neither. This
+    /// way the eight sectors tile the circle exactly once.
+    static func sectorOwns(compass: Double, angle: Double) -> Bool {
+        var delta = (angle - compass).truncatingRemainder(dividingBy: 360)
+        if delta < -180 { delta += 360 }
+        if delta >= 180 { delta -= 360 }
+        return delta >= -sectorWidth / 2 && delta < sectorWidth / 2
+    }
+
+    // MARK: - Matching
+
+    /// `compassAngle` nil means the centre pose.
+    static func matches(yaw: Float, pitch: Float, compassAngle: Double?, factor: Float) -> Bool {
+        guard let compass = compassAngle else {
+            return abs(yaw) < yawCenterTolerance * factor && abs(pitch) < pitchCenterTolerance * factor
+        }
+        let turn = turn(yaw: yaw, pitch: pitch)
+        guard turn.magnitude >= requiredMagnitude(factor: factor), turn.isWithinRange else { return false }
+        return sectorOwns(compass: compass, angle: turn.compassAngle)
+    }
+}

--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -59,25 +59,6 @@ enum OnboardingStep: String, CaseIterable {
 enum EnrollmentPose: Int, CaseIterable {
     case center, left, topLeft, top, topRight, right, bottomRight, bottom, bottomLeft
 
-    enum YawBand { case left, none, right }
-    enum PitchBand { case up, none, down }
-
-    var yawBand: YawBand {
-        switch self {
-        case .left, .topLeft, .bottomLeft: return .left
-        case .right, .topRight, .bottomRight: return .right
-        case .center, .top, .bottom: return .none
-        }
-    }
-
-    var pitchBand: PitchBand {
-        switch self {
-        case .top, .topLeft, .topRight: return .up
-        case .bottom, .bottomLeft, .bottomRight: return .down
-        case .center, .left, .right: return .none
-        }
-    }
-
     /// Compass angle (0 = up, clockwise) this pose's ring sector is centered
     /// on. `nil` for center, which pulses the whole ring instead of
     /// claiming a sector.
@@ -367,10 +348,13 @@ final class OnboardingController {
     // preview. Pitch's sign is the opposite of the initial guess — see `pitchMatches` below.
     private let yawInnerThreshold: Float = 0.25
     private let yawCenterTolerance: Float = 0.18
-    private let yawOuterCap: Float = 1.2
     private let pitchInnerThreshold: Float = 0.20
     private let pitchCenterTolerance: Float = 0.15
-    private let pitchOuterCap: Float = 0.9
+    /// Half of a 45-degree ring sector, so a turn counts toward the sector it actually points at and no other.
+    private let poseSectorTolerance: Double = 22.5
+    /// Replaces the old per-axis outer caps, which rejected wild Vision estimates. In `TurnVector` units those were
+    /// yawOuterCap/yawInnerThreshold = 4.8 and pitchOuterCap/pitchInnerThreshold = 4.5; the lower keeps the stricter.
+    private let outerMagnitudeCap: Double = 4.5
     /// If a pose takes longer than this, matching bands widen by `stallWidenFactor` so an
     /// unusual camera angle can't permanently strand the user.
     private let stallTimeout: Duration = .seconds(12)
@@ -448,22 +432,45 @@ final class OnboardingController {
     /// Below this fraction of the threshold the direction is mostly sensor noise.
     private let headTurnDeadzone: Double = 0.15
 
-    /// Live head direction, or `nil` when there's nothing to point at. Axes are normalized
-    /// against the current pose's thresholds, so `progress` hits 1 as the pose starts matching.
+    /// Where the head is pointing, normalized so 1.0 means "turned far enough". Both the ring the user is watching
+    /// and the gate that accepts a pose read this, so the two cannot drift apart — see `poseMatches`.
+    private struct TurnVector {
+        /// Screen-right, in units of `yawInnerThreshold`.
+        let x: Double
+        /// Up, in units of `pitchInnerThreshold`.
+        let y: Double
+
+        var magnitude: Double { (x * x + y * y).squareRoot() }
+
+        /// Compass degrees, 0 = up, clockwise — the same frame as `EnrollmentPose.compassAngle`.
+        var compassAngle: Double {
+            let degrees = atan2(x, y) * 180 / .pi
+            return degrees < 0 ? degrees + 360 : degrees
+        }
+    }
+
+    /// Vision inverts both axes against the screen: +yaw turns left, +pitch looks down.
+    private func normalizedTurn(yaw: Float, pitch: Float) -> TurnVector {
+        TurnVector(x: Double(-yaw / yawInnerThreshold), y: Double(-pitch / pitchInnerThreshold))
+    }
+
+    /// How far the head must turn for `pose`, in `TurnVector` units. Leniency and the stall widening both shrink it,
+    /// exactly as they used to scale the rectangular bands.
+    private func requiredMagnitude(for pose: EnrollmentPose, widened: Bool) -> Double {
+        1.0 / Double((widened ? stallWidenFactor : 1.0) * pose.matchLeniency)
+    }
+
+    /// Live head direction, or `nil` when there's nothing to point at. `progress` hits 1 exactly when the pose starts
+    /// matching, which is now true for the diagonals too.
     var headTurn: HeadTurn? {
         guard step == .enroll, !enrollmentComplete, faceDetected, !isTooFar,
               let pose = currentPose, pose != .center,
               let yaw = currentYaw, let pitch = currentPitch else { return nil }
 
-        // Vision inverts both axes vs. the screen: +yaw turns left, +pitch looks down.
-        let x = Double(-yaw / (yawInnerThreshold / pose.matchLeniency))
-        let y = Double(-pitch / (pitchInnerThreshold / pose.matchLeniency))
-
-        let magnitude = (x * x + y * y).squareRoot()
-        guard magnitude > headTurnDeadzone else { return nil }
-
-        let degrees = atan2(x, y) * 180 / .pi
-        return HeadTurn(angle: degrees < 0 ? degrees + 360 : degrees, progress: min(magnitude, 1))
+        let turn = normalizedTurn(yaw: yaw, pitch: pitch)
+        let required = requiredMagnitude(for: pose, widened: false)
+        guard turn.magnitude > headTurnDeadzone * required else { return nil }
+        return HeadTurn(angle: turn.compassAngle, progress: min(turn.magnitude / required, 1))
     }
 
     private enum EnrollFrameOutcome: Sendable {
@@ -817,28 +824,31 @@ final class OnboardingController {
         }
     }
 
+    /// A directional pose matches when the head has turned far enough *in that direction*, measured the same way the
+    /// progress ring measures it.
+    ///
+    /// This used to test yaw and pitch independently, which quietly made the four diagonals 1.41x harder than the ring
+    /// implied: a perfect 45-degree turn puts 0.707 on each axis and fills the ring to 100%, but each axis still had to
+    /// reach 1.0 on its own, so the user had to keep turning past the point where the UI said they were done, with no
+    /// feedback explaining why. Cardinal poses were unaffected, which is why only the diagonals felt impossible.
     private func poseMatches(yaw: Float, pitch: Float, pose: EnrollmentPose, widened: Bool) -> Bool {
         let factor = (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
-        return yawMatches(yaw, band: pose.yawBand, factor: factor)
-            && pitchMatches(pitch, band: pose.pitchBand, factor: factor)
+        guard let compass = pose.compassAngle else {
+            // Centre is a box around the origin rather than a direction, and was never the problem — left as it was.
+            return abs(yaw) < yawCenterTolerance * factor && abs(pitch) < pitchCenterTolerance * factor
+        }
+
+        let turn = normalizedTurn(yaw: yaw, pitch: pitch)
+        guard turn.magnitude >= requiredMagnitude(for: pose, widened: widened),
+              turn.magnitude <= outerMagnitudeCap
+        else { return false }
+        return Self.angularDistance(turn.compassAngle, compass) <= poseSectorTolerance
     }
 
-    private func yawMatches(_ yaw: Float, band: EnrollmentPose.YawBand, factor: Float) -> Bool {
-        switch band {
-        case .none: return abs(yaw) < yawCenterTolerance * factor
-        case .left: return yaw > yawInnerThreshold / factor && yaw < yawOuterCap
-        case .right: return yaw < -yawInnerThreshold / factor && yaw > -yawOuterCap
-        }
-    }
-
-    /// Confirmed empirically: Vision reports negative pitch for "looking up" and positive
-    /// for "looking down" — the opposite of the initial guess.
-    private func pitchMatches(_ pitch: Float, band: EnrollmentPose.PitchBand, factor: Float) -> Bool {
-        switch band {
-        case .none: return abs(pitch) < pitchCenterTolerance * factor
-        case .up: return pitch < -pitchInnerThreshold / factor && pitch > -pitchOuterCap
-        case .down: return pitch > pitchInnerThreshold / factor && pitch < pitchOuterCap
-        }
+    /// Smallest absolute separation between two compass angles, in degrees.
+    private static func angularDistance(_ a: Double, _ b: Double) -> Double {
+        let delta = abs(a - b).truncatingRemainder(dividingBy: 360)
+        return min(delta, 360 - delta)
     }
 
     /// Runs the camera-complete sequence (instructions fade, preview fades, checkmark

--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -346,15 +346,8 @@ final class OnboardingController {
 
     // Pose-matching bands, in radians. Yaw: left turn is positive, matching the mirrored
     // preview. Pitch's sign is the opposite of the initial guess — see `pitchMatches` below.
-    private let yawInnerThreshold: Float = 0.25
-    private let yawCenterTolerance: Float = 0.18
-    private let pitchInnerThreshold: Float = 0.20
-    private let pitchCenterTolerance: Float = 0.15
-    /// Half of a 45-degree ring sector, so a turn counts toward the sector it actually points at and no other.
-    private let poseSectorTolerance: Double = 22.5
-    /// Replaces the old per-axis outer caps, which rejected wild Vision estimates. In `TurnVector` units those were
-    /// yawOuterCap/yawInnerThreshold = 4.8 and pitchOuterCap/pitchInnerThreshold = 4.5; the lower keeps the stricter.
-    private let outerMagnitudeCap: Double = 4.5
+    // Pose geometry — thresholds, sectors and the matching itself — lives in EnrollmentPoseGeometry, which is pure
+    // and dependency-free so tools/enrollment_selftest.swift compiles the shipping source rather than a copy.
     /// If a pose takes longer than this, matching bands widen by `stallWidenFactor` so an
     /// unusual camera angle can't permanently strand the user.
     private let stallTimeout: Duration = .seconds(12)
@@ -432,32 +425,9 @@ final class OnboardingController {
     /// Below this fraction of the threshold the direction is mostly sensor noise.
     private let headTurnDeadzone: Double = 0.15
 
-    /// Where the head is pointing, normalized so 1.0 means "turned far enough". Both the ring the user is watching
-    /// and the gate that accepts a pose read this, so the two cannot drift apart — see `poseMatches`.
-    private struct TurnVector {
-        /// Screen-right, in units of `yawInnerThreshold`.
-        let x: Double
-        /// Up, in units of `pitchInnerThreshold`.
-        let y: Double
-
-        var magnitude: Double { (x * x + y * y).squareRoot() }
-
-        /// Compass degrees, 0 = up, clockwise — the same frame as `EnrollmentPose.compassAngle`.
-        var compassAngle: Double {
-            let degrees = atan2(x, y) * 180 / .pi
-            return degrees < 0 ? degrees + 360 : degrees
-        }
-    }
-
-    /// Vision inverts both axes against the screen: +yaw turns left, +pitch looks down.
-    private func normalizedTurn(yaw: Float, pitch: Float) -> TurnVector {
-        TurnVector(x: Double(-yaw / yawInnerThreshold), y: Double(-pitch / pitchInnerThreshold))
-    }
-
-    /// How far the head must turn for `pose`, in `TurnVector` units. Leniency and the stall widening both shrink it,
-    /// exactly as they used to scale the rectangular bands.
-    private func requiredMagnitude(for pose: EnrollmentPose, widened: Bool) -> Double {
-        1.0 / Double((widened ? stallWidenFactor : 1.0) * pose.matchLeniency)
+    /// Folds per-pose leniency and the stall widening into one number for `EnrollmentPoseGeometry`.
+    private func matchFactor(for pose: EnrollmentPose, widened: Bool) -> Float {
+        (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
     }
 
     /// Live head direction, or `nil` when there's nothing to point at. `progress` hits 1 exactly when the pose starts
@@ -467,9 +437,12 @@ final class OnboardingController {
               let pose = currentPose, pose != .center,
               let yaw = currentYaw, let pitch = currentPitch else { return nil }
 
-        let turn = normalizedTurn(yaw: yaw, pitch: pitch)
-        let required = requiredMagnitude(for: pose, widened: false)
+        let turn = EnrollmentPoseGeometry.turn(yaw: yaw, pitch: pitch)
+        let required = EnrollmentPoseGeometry.requiredMagnitude(factor: matchFactor(for: pose, widened: false))
         guard turn.magnitude > headTurnDeadzone * required else { return nil }
+        // Over-rotated far enough that no pose will accept the turn, so the ring must not read as ready either —
+        // showing a full indicator against a refusing gate is the exact mismatch this whole change exists to remove.
+        guard turn.isWithinRange else { return nil }
         return HeadTurn(angle: turn.compassAngle, progress: min(turn.magnitude / required, 1))
     }
 
@@ -832,23 +805,12 @@ final class OnboardingController {
     /// reach 1.0 on its own, so the user had to keep turning past the point where the UI said they were done, with no
     /// feedback explaining why. Cardinal poses were unaffected, which is why only the diagonals felt impossible.
     private func poseMatches(yaw: Float, pitch: Float, pose: EnrollmentPose, widened: Bool) -> Bool {
-        let factor = (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
-        guard let compass = pose.compassAngle else {
-            // Centre is a box around the origin rather than a direction, and was never the problem — left as it was.
-            return abs(yaw) < yawCenterTolerance * factor && abs(pitch) < pitchCenterTolerance * factor
-        }
-
-        let turn = normalizedTurn(yaw: yaw, pitch: pitch)
-        guard turn.magnitude >= requiredMagnitude(for: pose, widened: widened),
-              turn.magnitude <= outerMagnitudeCap
-        else { return false }
-        return Self.angularDistance(turn.compassAngle, compass) <= poseSectorTolerance
-    }
-
-    /// Smallest absolute separation between two compass angles, in degrees.
-    private static func angularDistance(_ a: Double, _ b: Double) -> Double {
-        let delta = abs(a - b).truncatingRemainder(dividingBy: 360)
-        return min(delta, 360 - delta)
+        EnrollmentPoseGeometry.matches(
+            yaw: yaw,
+            pitch: pitch,
+            compassAngle: pose.compassAngle,
+            factor: matchFactor(for: pose, widened: widened)
+        )
     }
 
     /// Runs the camera-complete sequence (instructions fade, preview fades, checkmark

--- a/tools/README.md
+++ b/tools/README.md
@@ -72,19 +72,28 @@ and latency change.
 simulated head and reports how hard enrollment is to finish.
 
 ```bash
-swiftc -O tools/enrollment_selftest.swift -o /tmp/enrollment_selftest
+swiftc -O tools/enrollment_selftest.swift glance/Onboarding/EnrollmentPoseGeometry.swift \
+    -o /tmp/enrollment_selftest
 /tmp/enrollment_selftest
 ```
 
-It asserts the two properties that matter and prints the numbers behind them:
+It compiles the shipping `EnrollmentPoseGeometry.swift` rather than a copy, so
+it cannot stay green while the app's matching drifts.
 
-1. **The ring and the gate agree.** `headTurn`'s progress and `poseMatches`
-   read the same normalized vector, so the ring can never fill while the pose
-   is still refused.
-2. **A diagonal costs no more head turn than a cardinal**, and a turn
-   satisfies only the sector it actually points at.
+It asserts the properties that matter and prints the numbers behind them:
+
+1. **The ring and the gate agree** for a turn pointing at the requested pose:
+   `headTurn`'s progress and `poseMatches` derive from the same normalized
+   vector and honour the same outer cap, so the ring can never read full while
+   the pose is refused. A turn pointing at a *different* sector is a separate
+   matter — the ring only ever describes the pose being asked for.
+2. **A diagonal costs no more head turn than a cardinal.**
+3. **The eight sectors tile the circle exactly once**, boundaries included: no
+   direction satisfies two poses, and none falls between them.
 
 It then simulates enrollment at three levels of user effort with a noisy
-yaw/pitch estimate, and prints time-to-enrol and give-up rate against the old
+yaw/pitch estimate, modelling the real capture loop — the 500 ms continuous
+hold, the match streak, and two samples per pose, with any non-matching frame
+restarting the hold. It prints time-to-enrol and give-up rate against the old
 rectangular matcher, which is kept in the file purely so the regression stays
 visible. The random source is seeded, so runs are reproducible.

--- a/tools/README.md
+++ b/tools/README.md
@@ -63,3 +63,28 @@ python tools/convert_arcface.py --onnx-path /path/to/w600k_mbf.onnx
 If you ever swap in a different ArcFace variant (e.g. `w600k_r50` via
 `--variant w600k_r50`), this contract stays the same — only the file size
 and latency change.
+
+---
+
+# Enrollment self-test
+
+`enrollment_selftest.swift` drives the guided-enrollment pose maths with a
+simulated head and reports how hard enrollment is to finish.
+
+```bash
+swiftc -O tools/enrollment_selftest.swift -o /tmp/enrollment_selftest
+/tmp/enrollment_selftest
+```
+
+It asserts the two properties that matter and prints the numbers behind them:
+
+1. **The ring and the gate agree.** `headTurn`'s progress and `poseMatches`
+   read the same normalized vector, so the ring can never fill while the pose
+   is still refused.
+2. **A diagonal costs no more head turn than a cardinal**, and a turn
+   satisfies only the sector it actually points at.
+
+It then simulates enrollment at three levels of user effort with a noisy
+yaw/pitch estimate, and prints time-to-enrol and give-up rate against the old
+rectangular matcher, which is kept in the file purely so the regression stays
+visible. The random source is seeded, so runs are reproducible.

--- a/tools/enrollment_selftest.swift
+++ b/tools/enrollment_selftest.swift
@@ -1,0 +1,276 @@
+//
+//  enrollment_selftest.swift
+//  glance
+//
+//  Measures how hard guided enrollment is to complete, by driving the real pose-matching maths with a simulated
+//  head. Same manual-script style as liveness_selftest.swift:
+//
+//      swiftc -O tools/enrollment_selftest.swift -o /tmp/enrollment_selftest && /tmp/enrollment_selftest
+//
+//  The interesting number is the gap between what the progress ring shows the user and what the gate actually
+//  requires. They are computed from one shared vector now; this asserts they stay that way.
+//
+
+import Foundation
+
+// MARK: - Constants, mirrored from OnboardingController
+
+let yawInnerThreshold: Float = 0.25
+let pitchInnerThreshold: Float = 0.20
+let yawCenterTolerance: Float = 0.18
+let pitchCenterTolerance: Float = 0.15
+let poseSectorTolerance: Double = 22.5
+let outerMagnitudeCap: Double = 4.5
+let stallWidenFactor: Float = 1.25
+
+enum Pose: String, CaseIterable {
+    case center, left, topLeft, top, topRight, right, bottomRight, bottom, bottomLeft
+
+    var compassAngle: Double? {
+        switch self {
+        case .center: return nil
+        case .left: return 270
+        case .topLeft: return 315
+        case .top: return 0
+        case .topRight: return 45
+        case .right: return 90
+        case .bottomRight: return 135
+        case .bottom: return 180
+        case .bottomLeft: return 225
+        }
+    }
+
+    var matchLeniency: Float {
+        switch self {
+        case .bottomLeft, .bottomRight: return 1.5
+        case .bottom: return 1.2
+        default: return 1
+        }
+    }
+
+    var isDiagonal: Bool {
+        switch self {
+        case .topLeft, .topRight, .bottomLeft, .bottomRight: return true
+        default: return false
+        }
+    }
+}
+
+// MARK: - The maths under test
+
+struct TurnVector {
+    let x: Double
+    let y: Double
+    var magnitude: Double { (x * x + y * y).squareRoot() }
+    var compassAngle: Double {
+        let d = atan2(x, y) * 180 / .pi
+        return d < 0 ? d + 360 : d
+    }
+}
+
+func normalizedTurn(yaw: Float, pitch: Float) -> TurnVector {
+    TurnVector(x: Double(-yaw / yawInnerThreshold), y: Double(-pitch / pitchInnerThreshold))
+}
+
+func requiredMagnitude(for pose: Pose, widened: Bool) -> Double {
+    1.0 / Double((widened ? stallWidenFactor : 1.0) * pose.matchLeniency)
+}
+
+func angularDistance(_ a: Double, _ b: Double) -> Double {
+    let d = abs(a - b).truncatingRemainder(dividingBy: 360)
+    return min(d, 360 - d)
+}
+
+/// Current implementation: one vector, shared with the ring.
+func poseMatches(yaw: Float, pitch: Float, pose: Pose, widened: Bool) -> Bool {
+    let factor = (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
+    guard let compass = pose.compassAngle else {
+        return abs(yaw) < yawCenterTolerance * factor && abs(pitch) < pitchCenterTolerance * factor
+    }
+    let turn = normalizedTurn(yaw: yaw, pitch: pitch)
+    guard turn.magnitude >= requiredMagnitude(for: pose, widened: widened),
+          turn.magnitude <= outerMagnitudeCap else { return false }
+    return angularDistance(turn.compassAngle, compass) <= poseSectorTolerance
+}
+
+/// What the ring shows the user, 0...1.
+func ringProgress(yaw: Float, pitch: Float, pose: Pose) -> Double {
+    let turn = normalizedTurn(yaw: yaw, pitch: pitch)
+    return min(turn.magnitude / requiredMagnitude(for: pose, widened: false), 1)
+}
+
+/// The previous rectangular test, kept only so the regression stays visible.
+func legacyPoseMatches(yaw: Float, pitch: Float, pose: Pose, widened: Bool) -> Bool {
+    let f = (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
+    let yawOuterCap: Float = 1.2, pitchOuterCap: Float = 0.9
+    let yawOK: Bool, pitchOK: Bool
+    switch pose {
+    case .left, .topLeft, .bottomLeft: yawOK = yaw > yawInnerThreshold / f && yaw < yawOuterCap
+    case .right, .topRight, .bottomRight: yawOK = yaw < -yawInnerThreshold / f && yaw > -yawOuterCap
+    default: yawOK = abs(yaw) < yawCenterTolerance * f
+    }
+    switch pose {
+    case .top, .topLeft, .topRight: pitchOK = pitch < -pitchInnerThreshold / f && pitch > -pitchOuterCap
+    case .bottom, .bottomLeft, .bottomRight: pitchOK = pitch > pitchInnerThreshold / f && pitch < pitchOuterCap
+    default: pitchOK = abs(pitch) < pitchCenterTolerance * f
+    }
+    return yawOK && pitchOK
+}
+
+/// Turn the head along `pose`'s own direction by `magnitude` normalized units, and report the raw Vision angles.
+func headAngles(towards pose: Pose, magnitude: Double) -> (yaw: Float, pitch: Float) {
+    guard let compass = pose.compassAngle else { return (0, 0) }
+    let radians = compass * .pi / 180
+    let x = sin(radians) * magnitude
+    let y = cos(radians) * magnitude
+    return (yaw: Float(-x * Double(yawInnerThreshold)), pitch: Float(-y * Double(pitchInnerThreshold)))
+}
+
+/// Seeded so a run is reproducible: a self-test that reports different numbers each time cannot be regression-checked.
+struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed &+ 0x9E3779B97F4A7C15 }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}
+
+var failures = 0
+func check(_ condition: Bool, _ label: String) {
+    print("  \(condition ? "PASS" : "FAIL")  \(label)")
+    if !condition { failures += 1 }
+}
+
+// MARK: - 1. The ring and the gate must agree
+
+print("\n1. Turn along each pose's own direction: where does the ring read 100%, where does the gate accept?\n")
+print(String(format: "   %-12@ %-10@ %-10@ %-10@ %@", "pose" as NSString, "ring 100%" as NSString,
+             "gate now" as NSString, "gate was" as NSString, "was/now" as NSString))
+
+for pose in Pose.allCases where pose != .center {
+    func firstMagnitude(_ test: (Float, Float) -> Bool) -> Double {
+        var m = 0.005
+        while m <= 5.0 {
+            let a = headAngles(towards: pose, magnitude: m)
+            if test(a.yaw, a.pitch) { return m }
+            m += 0.005
+        }
+        return .nan
+    }
+    let ring = firstMagnitude { ringProgress(yaw: $0, pitch: $1, pose: pose) >= 1.0 }
+    let now = firstMagnitude { poseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }
+    let was = firstMagnitude { legacyPoseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }
+    print(String(format: "   %-12@ %-10.2f %-10.2f %-10.2f %.2fx", pose.rawValue as NSString, ring, now, was, was / now))
+}
+
+print("")
+for pose in Pose.allCases where pose != .center {
+    var worst = 0.0
+    var m = 0.005
+    while m <= 3.0 {
+        let a = headAngles(towards: pose, magnitude: m)
+        let ringSaysDone = ringProgress(yaw: a.yaw, pitch: a.pitch, pose: pose) >= 1.0
+        let gateAccepts = poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false)
+        if ringSaysDone != gateAccepts { worst = max(worst, m) }
+        m += 0.005
+    }
+    check(worst == 0, "\(pose.rawValue): ring and gate agree at every turn magnitude")
+}
+
+// MARK: - 2. Diagonals must not be harder than cardinals
+
+print("\n2. A diagonal should cost the same head turn as a cardinal\n")
+let cardinalCost = ["left", "top", "right"].compactMap { name in
+    Pose.allCases.first { $0.rawValue == name }
+}.map { pose -> Double in
+    var m = 0.005
+    while m <= 5.0 {
+        let a = headAngles(towards: pose, magnitude: m)
+        if poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false) { return m }
+        m += 0.005
+    }
+    return .nan
+}
+let worstCardinal = cardinalCost.max() ?? .nan
+for pose in Pose.allCases where pose.isDiagonal {
+    var m = 0.005
+    var cost = Double.nan
+    while m <= 5.0 {
+        let a = headAngles(towards: pose, magnitude: m)
+        if poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false) { cost = m; break }
+        m += 0.005
+    }
+    check(cost <= worstCardinal + 0.01, String(format: "%@ costs %.2f, no worse than the %.2f a cardinal costs",
+                                               pose.rawValue, cost, worstCardinal))
+}
+
+// MARK: - 3. A turn must only satisfy the sector it points at
+
+print("\n3. A turn must satisfy only the pose it points at\n")
+for pose in Pose.allCases where pose != .center {
+    let a = headAngles(towards: pose, magnitude: 1.6)
+    let matched = Pose.allCases.filter { poseMatches(yaw: a.yaw, pitch: a.pitch, pose: $0, widened: false) }
+    check(matched == [pose], "turning toward \(pose.rawValue) matches only \(pose.rawValue) (got \(matched.map(\.rawValue)))")
+}
+
+// MARK: - 4. Looking straight ahead is still centre, and only centre
+
+print("\n4. Looking straight ahead\n")
+let straight = Pose.allCases.filter { poseMatches(yaw: 0, pitch: 0, pose: $0, widened: false) }
+check(straight == [.center], "a still head matches only centre (got \(straight.map(\.rawValue)))")
+
+// MARK: - 5. Noisy heads: can a real person finish?
+
+print("\n5. Simulated enrollment with a noisy head estimate\n")
+
+/// Vision's yaw/pitch on a 2D webcam jitters. Model a user who aims at the requested sector and overshoots or
+/// undershoots, with per-frame noise on top, and count how many frames it takes to satisfy each pose.
+func simulate(matcher: (Float, Float, Pose, Bool) -> Bool, aim: Double, noise: Double, seed: UInt64) -> Int? {
+    var rng = SplitMix64(seed: seed)
+    var frames = 0
+    for pose in Pose.allCases {
+        var streak = 0
+        var poseFrames = 0
+        while streak < 3 {
+            poseFrames += 1
+            frames += 1
+            if poseFrames > 600 { return nil }          // ~20s at 30fps: the user gave up
+            let widened = poseFrames > 360              // stallTimeout 12s
+            let jitterX = Double.random(in: -noise...noise, using: &rng)
+            let jitterY = Double.random(in: -noise...noise, using: &rng)
+            let (yaw, pitch): (Float, Float)
+            if pose == .center {
+                yaw = Float(jitterX * Double(yawInnerThreshold))
+                pitch = Float(jitterY * Double(pitchInnerThreshold))
+            } else {
+                let base = headAngles(towards: pose, magnitude: aim)
+                yaw = base.yaw + Float(jitterX * Double(yawInnerThreshold))
+                pitch = base.pitch + Float(jitterY * Double(pitchInnerThreshold))
+            }
+            streak = matcher(yaw, pitch, pose, widened) ? streak + 1 : 0
+        }
+    }
+    return frames
+}
+
+for (label, aim) in [("a cautious user (turns just to the ring's 100% mark)", 1.05),
+                     ("an average user (turns a bit past it)", 1.3),
+                     ("a generous user (turns well past it)", 1.8)] {
+    var nowFrames: [Int] = [], wasFrames: [Int] = []
+    var nowGaveUp = 0, wasGaveUp = 0
+    for seed in 0..<200 {
+        if let f = simulate(matcher: poseMatches, aim: aim, noise: 0.25, seed: UInt64(seed)) { nowFrames.append(f) } else { nowGaveUp += 1 }
+        if let f = simulate(matcher: legacyPoseMatches, aim: aim, noise: 0.25, seed: UInt64(seed)) { wasFrames.append(f) } else { wasGaveUp += 1 }
+    }
+    func secs(_ v: [Int]) -> String { v.isEmpty ? "never" : String(format: "%.1fs", Double(v.reduce(0,+)) / Double(v.count) / 30.0) }
+    print("   \(label), aiming \(aim)x:")
+    print(String(format: "     now: %@ to enrol, gave up %d/200", secs(nowFrames) as NSString, nowGaveUp))
+    print(String(format: "     was: %@ to enrol, gave up %d/200", secs(wasFrames) as NSString, wasGaveUp))
+}
+
+print("\n\(failures == 0 ? "All checks passed." : "\(failures) check(s) FAILED.")")
+exit(failures == 0 ? 0 : 1)

--- a/tools/enrollment_selftest.swift
+++ b/tools/enrollment_selftest.swift
@@ -2,26 +2,18 @@
 //  enrollment_selftest.swift
 //  glance
 //
-//  Measures how hard guided enrollment is to complete, by driving the real pose-matching maths with a simulated
-//  head. Same manual-script style as liveness_selftest.swift:
+//  Measures how hard guided enrollment is to finish. Compiles the shipping geometry directly — the point is to test
+//  glance/Onboarding/EnrollmentPoseGeometry.swift, not a copy of it, so this cannot stay green while the app drifts:
 //
-//      swiftc -O tools/enrollment_selftest.swift -o /tmp/enrollment_selftest && /tmp/enrollment_selftest
+//      swiftc -O tools/enrollment_selftest.swift glance/Onboarding/EnrollmentPoseGeometry.swift \
+//          -o /tmp/enrollment_selftest && /tmp/enrollment_selftest
 //
-//  The interesting number is the gap between what the progress ring shows the user and what the gate actually
-//  requires. They are computed from one shared vector now; this asserts they stay that way.
+//  Same manual-script style as liveness_selftest.swift.
 //
 
 import Foundation
 
-// MARK: - Constants, mirrored from OnboardingController
-
-let yawInnerThreshold: Float = 0.25
-let pitchInnerThreshold: Float = 0.20
-let yawCenterTolerance: Float = 0.18
-let pitchCenterTolerance: Float = 0.15
-let poseSectorTolerance: Double = 22.5
-let outerMagnitudeCap: Double = 4.5
-let stallWidenFactor: Float = 1.25
+// MARK: - Mirrored from OnboardingController: the pose table and the capture-loop timings
 
 enum Pose: String, CaseIterable {
     case center, left, topLeft, top, topRight, right, bottomRight, bottom, bottomLeft
@@ -56,77 +48,65 @@ enum Pose: String, CaseIterable {
     }
 }
 
-// MARK: - The maths under test
+let stallWidenFactor: Float = 1.25
+let requiredMatchStreak = 3
+let samplesPerPose = 2
+let poseHoldFrames = 15        // poseHoldDuration 500ms at 30fps
+let stallTimeoutFrames = 360   // stallTimeout 12s at 30fps
+let framesPerSecond = 30.0
 
-struct TurnVector {
-    let x: Double
-    let y: Double
-    var magnitude: Double { (x * x + y * y).squareRoot() }
-    var compassAngle: Double {
-        let d = atan2(x, y) * 180 / .pi
-        return d < 0 ? d + 360 : d
-    }
+func factor(for pose: Pose, widened: Bool) -> Float {
+    (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
 }
 
-func normalizedTurn(yaw: Float, pitch: Float) -> TurnVector {
-    TurnVector(x: Double(-yaw / yawInnerThreshold), y: Double(-pitch / pitchInnerThreshold))
-}
-
-func requiredMagnitude(for pose: Pose, widened: Bool) -> Double {
-    1.0 / Double((widened ? stallWidenFactor : 1.0) * pose.matchLeniency)
-}
-
-func angularDistance(_ a: Double, _ b: Double) -> Double {
-    let d = abs(a - b).truncatingRemainder(dividingBy: 360)
-    return min(d, 360 - d)
-}
-
-/// Current implementation: one vector, shared with the ring.
+/// The shipping matcher.
 func poseMatches(yaw: Float, pitch: Float, pose: Pose, widened: Bool) -> Bool {
-    let factor = (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
-    guard let compass = pose.compassAngle else {
-        return abs(yaw) < yawCenterTolerance * factor && abs(pitch) < pitchCenterTolerance * factor
-    }
-    let turn = normalizedTurn(yaw: yaw, pitch: pitch)
-    guard turn.magnitude >= requiredMagnitude(for: pose, widened: widened),
-          turn.magnitude <= outerMagnitudeCap else { return false }
-    return angularDistance(turn.compassAngle, compass) <= poseSectorTolerance
+    EnrollmentPoseGeometry.matches(yaw: yaw, pitch: pitch, compassAngle: pose.compassAngle,
+                                   factor: factor(for: pose, widened: widened))
 }
 
-/// What the ring shows the user, 0...1.
+/// What the ring shows, from the same vector `headTurn` uses.
 func ringProgress(yaw: Float, pitch: Float, pose: Pose) -> Double {
-    let turn = normalizedTurn(yaw: yaw, pitch: pitch)
-    return min(turn.magnitude / requiredMagnitude(for: pose, widened: false), 1)
+    let turn = EnrollmentPoseGeometry.turn(yaw: yaw, pitch: pitch)
+    guard turn.isWithinRange else { return 0 }
+    return min(turn.magnitude / EnrollmentPoseGeometry.requiredMagnitude(factor: factor(for: pose, widened: false)), 1)
 }
 
-/// The previous rectangular test, kept only so the regression stays visible.
+/// The previous rectangular test, frozen here purely so the regression stays visible.
 func legacyPoseMatches(yaw: Float, pitch: Float, pose: Pose, widened: Bool) -> Bool {
-    let f = (widened ? stallWidenFactor : 1.0) * pose.matchLeniency
+    let f = factor(for: pose, widened: widened)
+    let yawInner: Float = 0.25, pitchInner: Float = 0.20
+    let yawCenterTol: Float = 0.18, pitchCenterTol: Float = 0.15
     let yawOuterCap: Float = 1.2, pitchOuterCap: Float = 0.9
     let yawOK: Bool, pitchOK: Bool
     switch pose {
-    case .left, .topLeft, .bottomLeft: yawOK = yaw > yawInnerThreshold / f && yaw < yawOuterCap
-    case .right, .topRight, .bottomRight: yawOK = yaw < -yawInnerThreshold / f && yaw > -yawOuterCap
-    default: yawOK = abs(yaw) < yawCenterTolerance * f
+    case .left, .topLeft, .bottomLeft: yawOK = yaw > yawInner / f && yaw < yawOuterCap
+    case .right, .topRight, .bottomRight: yawOK = yaw < -yawInner / f && yaw > -yawOuterCap
+    default: yawOK = abs(yaw) < yawCenterTol * f
     }
     switch pose {
-    case .top, .topLeft, .topRight: pitchOK = pitch < -pitchInnerThreshold / f && pitch > -pitchOuterCap
-    case .bottom, .bottomLeft, .bottomRight: pitchOK = pitch > pitchInnerThreshold / f && pitch < pitchOuterCap
-    default: pitchOK = abs(pitch) < pitchCenterTolerance * f
+    case .top, .topLeft, .topRight: pitchOK = pitch < -pitchInner / f && pitch > -pitchOuterCap
+    case .bottom, .bottomLeft, .bottomRight: pitchOK = pitch > pitchInner / f && pitch < pitchOuterCap
+    default: pitchOK = abs(pitch) < pitchCenterTol * f
     }
     return yawOK && pitchOK
 }
 
-/// Turn the head along `pose`'s own direction by `magnitude` normalized units, and report the raw Vision angles.
-func headAngles(towards pose: Pose, magnitude: Double) -> (yaw: Float, pitch: Float) {
-    guard let compass = pose.compassAngle else { return (0, 0) }
+/// Turn the head `magnitude` normalized units along `compass`, and report the raw Vision angles.
+func headAngles(compass: Double, magnitude: Double) -> (yaw: Float, pitch: Float) {
     let radians = compass * .pi / 180
     let x = sin(radians) * magnitude
     let y = cos(radians) * magnitude
-    return (yaw: Float(-x * Double(yawInnerThreshold)), pitch: Float(-y * Double(pitchInnerThreshold)))
+    return (yaw: Float(-x * Double(EnrollmentPoseGeometry.yawInnerThreshold)),
+            pitch: Float(-y * Double(EnrollmentPoseGeometry.pitchInnerThreshold)))
 }
 
-/// Seeded so a run is reproducible: a self-test that reports different numbers each time cannot be regression-checked.
+func headAngles(towards pose: Pose, magnitude: Double) -> (yaw: Float, pitch: Float) {
+    guard let compass = pose.compassAngle else { return (0, 0) }
+    return headAngles(compass: compass, magnitude: magnitude)
+}
+
+/// Seeded so a run is reproducible: a self-test reporting different numbers each time cannot be regression-checked.
 struct SplitMix64: RandomNumberGenerator {
     private var state: UInt64
     init(seed: UInt64) { state = seed &+ 0x9E3779B97F4A7C15 }
@@ -145,132 +125,150 @@ func check(_ condition: Bool, _ label: String) {
     if !condition { failures += 1 }
 }
 
-// MARK: - 1. The ring and the gate must agree
-
-print("\n1. Turn along each pose's own direction: where does the ring read 100%, where does the gate accept?\n")
-print(String(format: "   %-12@ %-10@ %-10@ %-10@ %@", "pose" as NSString, "ring 100%" as NSString,
-             "gate now" as NSString, "gate was" as NSString, "was/now" as NSString))
-
-for pose in Pose.allCases where pose != .center {
-    func firstMagnitude(_ test: (Float, Float) -> Bool) -> Double {
-        var m = 0.005
-        while m <= 5.0 {
-            let a = headAngles(towards: pose, magnitude: m)
-            if test(a.yaw, a.pitch) { return m }
-            m += 0.005
-        }
-        return .nan
-    }
-    let ring = firstMagnitude { ringProgress(yaw: $0, pitch: $1, pose: pose) >= 1.0 }
-    let now = firstMagnitude { poseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }
-    let was = firstMagnitude { legacyPoseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }
-    print(String(format: "   %-12@ %-10.2f %-10.2f %-10.2f %.2fx", pose.rawValue as NSString, ring, now, was, was / now))
-}
-
-print("")
-for pose in Pose.allCases where pose != .center {
-    var worst = 0.0
-    var m = 0.005
-    while m <= 3.0 {
-        let a = headAngles(towards: pose, magnitude: m)
-        let ringSaysDone = ringProgress(yaw: a.yaw, pitch: a.pitch, pose: pose) >= 1.0
-        let gateAccepts = poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false)
-        if ringSaysDone != gateAccepts { worst = max(worst, m) }
-        m += 0.005
-    }
-    check(worst == 0, "\(pose.rawValue): ring and gate agree at every turn magnitude")
-}
-
-// MARK: - 2. Diagonals must not be harder than cardinals
-
-print("\n2. A diagonal should cost the same head turn as a cardinal\n")
-let cardinalCost = ["left", "top", "right"].compactMap { name in
-    Pose.allCases.first { $0.rawValue == name }
-}.map { pose -> Double in
+func firstMagnitude(_ test: (Float, Float) -> Bool, towards pose: Pose) -> Double {
     var m = 0.005
     while m <= 5.0 {
         let a = headAngles(towards: pose, magnitude: m)
-        if poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false) { return m }
+        if test(a.yaw, a.pitch) { return m }
         m += 0.005
     }
     return .nan
 }
-let worstCardinal = cardinalCost.max() ?? .nan
-for pose in Pose.allCases where pose.isDiagonal {
-    var m = 0.005
-    var cost = Double.nan
-    while m <= 5.0 {
-        let a = headAngles(towards: pose, magnitude: m)
-        if poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false) { cost = m; break }
-        m += 0.005
+
+/// Top-level statements are only legal in a file called main.swift, and this script is compiled alongside the app's
+/// own EnrollmentPoseGeometry.swift — so the runnable part lives in `main()`.
+@main
+enum EnrollmentSelfTest {
+    static func main() {
+    // MARK: - 1. The ring and the gate must agree
+
+    print("\n1. Turn along each pose's own direction: where does the ring read 100%, where does the gate accept?\n")
+    print(String(format: "   %-12@ %-10@ %-10@ %-10@ %@", "pose" as NSString, "ring 100%" as NSString,
+                 "gate now" as NSString, "gate was" as NSString, "was/now" as NSString))
+    for pose in Pose.allCases where pose != .center {
+        let ring = firstMagnitude({ ringProgress(yaw: $0, pitch: $1, pose: pose) >= 1.0 }, towards: pose)
+        let now = firstMagnitude({ poseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }, towards: pose)
+        let was = firstMagnitude({ legacyPoseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }, towards: pose)
+        print(String(format: "   %-12@ %-10.2f %-10.2f %-10.2f %.2fx", pose.rawValue as NSString, ring, now, was, was / now))
     }
-    check(cost <= worstCardinal + 0.01, String(format: "%@ costs %.2f, no worse than the %.2f a cardinal costs",
-                                               pose.rawValue, cost, worstCardinal))
-}
 
-// MARK: - 3. A turn must only satisfy the sector it points at
+    print("")
+    for pose in Pose.allCases where pose != .center {
+        var disagreed = false
+        var m = 0.005
+        while m <= 6.0 {
+            let a = headAngles(towards: pose, magnitude: m)
+            let ringReady = ringProgress(yaw: a.yaw, pitch: a.pitch, pose: pose) >= 1.0
+            if ringReady != poseMatches(yaw: a.yaw, pitch: a.pitch, pose: pose, widened: false) { disagreed = true; break }
+            m += 0.005
+        }
+        check(!disagreed, "\(pose.rawValue): ring and gate agree at every magnitude, including past the outer cap")
+    }
 
-print("\n3. A turn must satisfy only the pose it points at\n")
-for pose in Pose.allCases where pose != .center {
-    let a = headAngles(towards: pose, magnitude: 1.6)
-    let matched = Pose.allCases.filter { poseMatches(yaw: a.yaw, pitch: a.pitch, pose: $0, widened: false) }
-    check(matched == [pose], "turning toward \(pose.rawValue) matches only \(pose.rawValue) (got \(matched.map(\.rawValue)))")
-}
+    // MARK: - 2. Diagonals must cost no more than cardinals
 
-// MARK: - 4. Looking straight ahead is still centre, and only centre
+    print("\n2. A diagonal should cost the same head turn as a cardinal\n")
+    let cardinals: [Pose] = [.left, .top, .right, .bottom]
+        let worstCardinal = cardinals
+            .map { pose in firstMagnitude({ poseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }, towards: pose) }
+            .max() ?? .nan
+    for pose in Pose.allCases where pose.isDiagonal {
+        let cost = firstMagnitude({ poseMatches(yaw: $0, pitch: $1, pose: pose, widened: false) }, towards: pose)
+        check(cost <= worstCardinal + 0.01,
+              String(format: "%@ costs %.2f, no worse than a cardinal's %.2f", pose.rawValue, cost, worstCardinal))
+    }
 
-print("\n4. Looking straight ahead\n")
-let straight = Pose.allCases.filter { poseMatches(yaw: 0, pitch: 0, pose: $0, widened: false) }
-check(straight == [.center], "a still head matches only centre (got \(straight.map(\.rawValue)))")
+    // MARK: - 3. Sectors must tile the circle exactly once, boundaries included
 
-// MARK: - 5. Noisy heads: can a real person finish?
+    print("\n3. Every direction belongs to exactly one sector\n")
+    var multiClaimed: [Double] = []
+    var unclaimed: [Double] = []
+    var degrees = 0.0
+    while degrees < 360 {
+        let a = headAngles(compass: degrees, magnitude: 1.6)
+        let owners = Pose.allCases.filter { poseMatches(yaw: a.yaw, pitch: a.pitch, pose: $0, widened: false) }
+        if owners.count > 1 { multiClaimed.append(degrees) }
+        if owners.isEmpty { unclaimed.append(degrees) }
+        degrees += 0.5
+    }
+    check(multiClaimed.isEmpty, "no direction satisfies two poses at once (\(multiClaimed.count) would)")
+    check(unclaimed.isEmpty, "no direction falls between sectors (\(unclaimed.count) would)")
 
-print("\n5. Simulated enrollment with a noisy head estimate\n")
-
-/// Vision's yaw/pitch on a 2D webcam jitters. Model a user who aims at the requested sector and overshoots or
-/// undershoots, with per-frame noise on top, and count how many frames it takes to satisfy each pose.
-func simulate(matcher: (Float, Float, Pose, Bool) -> Bool, aim: Double, noise: Double, seed: UInt64) -> Int? {
-    var rng = SplitMix64(seed: seed)
-    var frames = 0
-    for pose in Pose.allCases {
-        var streak = 0
-        var poseFrames = 0
-        while streak < 3 {
-            poseFrames += 1
-            frames += 1
-            if poseFrames > 600 { return nil }          // ~20s at 30fps: the user gave up
-            let widened = poseFrames > 360              // stallTimeout 12s
-            let jitterX = Double.random(in: -noise...noise, using: &rng)
-            let jitterY = Double.random(in: -noise...noise, using: &rng)
-            let (yaw, pitch): (Float, Float)
-            if pose == .center {
-                yaw = Float(jitterX * Double(yawInnerThreshold))
-                pitch = Float(jitterY * Double(pitchInnerThreshold))
-            } else {
-                let base = headAngles(towards: pose, magnitude: aim)
-                yaw = base.yaw + Float(jitterX * Double(yawInnerThreshold))
-                pitch = base.pitch + Float(jitterY * Double(pitchInnerThreshold))
-            }
-            streak = matcher(yaw, pitch, pose, widened) ? streak + 1 : 0
+    // exact sector boundaries are the case a centre-only test misses
+    for pose in Pose.allCases where pose != .center {
+        guard let compass = pose.compassAngle else { continue }
+        for edge in [compass - 22.5, compass + 22.5] {
+            let a = headAngles(compass: edge, magnitude: 1.6)
+            let owners = Pose.allCases.filter { poseMatches(yaw: a.yaw, pitch: a.pitch, pose: $0, widened: false) }
+            check(owners.count == 1, String(format: "boundary %.1f deg is owned by exactly one pose (%@)", edge,
+                                            owners.map(\.rawValue).joined(separator: ",") as NSString))
         }
     }
-    return frames
-}
 
-for (label, aim) in [("a cautious user (turns just to the ring's 100% mark)", 1.05),
-                     ("an average user (turns a bit past it)", 1.3),
-                     ("a generous user (turns well past it)", 1.8)] {
-    var nowFrames: [Int] = [], wasFrames: [Int] = []
-    var nowGaveUp = 0, wasGaveUp = 0
-    for seed in 0..<200 {
-        if let f = simulate(matcher: poseMatches, aim: aim, noise: 0.25, seed: UInt64(seed)) { nowFrames.append(f) } else { nowGaveUp += 1 }
-        if let f = simulate(matcher: legacyPoseMatches, aim: aim, noise: 0.25, seed: UInt64(seed)) { wasFrames.append(f) } else { wasGaveUp += 1 }
+    // MARK: - 4. Looking straight ahead
+
+    print("\n4. Looking straight ahead\n")
+    let straight = Pose.allCases.filter { poseMatches(yaw: 0, pitch: 0, pose: $0, widened: false) }
+    check(straight == [.center], "a still head matches only centre (got \(straight.map(\.rawValue)))")
+
+    // MARK: - 5. Full enrollment, modelling the real capture loop
+
+    print("\n5. Simulated enrollment, modelling processMatchedEnrollFrame\n")
+    print("   (per pose: 500ms continuous hold, then \(requiredMatchStreak) matching frames per sample,")
+    print("    \(samplesPerPose) samples per pose; any non-matching frame restarts the hold)\n")
+
+    func simulate(matcher: (Float, Float, Pose, Bool) -> Bool, aim: Double, noise: Double, seed: UInt64) -> Int? {
+        var rng = SplitMix64(seed: seed)
+        var totalFrames = 0
+        for pose in Pose.allCases {
+            var poseFrames = 0
+            var holdFrames = 0          // poseHoldStartedAt
+            var holding = false
+            var streak = 0              // matchStreak
+            var samples = 0             // capturedForCurrentPose
+            while samples < samplesPerPose {
+                poseFrames += 1
+                totalFrames += 1
+                if poseFrames > 900 { return nil }           // 30s on one pose: the user gave up
+                let widened = poseFrames > stallTimeoutFrames
+                let jitterX = Double.random(in: -noise...noise, using: &rng)
+                let jitterY = Double.random(in: -noise...noise, using: &rng)
+                let base = pose == .center ? (yaw: Float(0), pitch: Float(0)) : headAngles(towards: pose, magnitude: aim)
+                let yaw = base.yaw + Float(jitterX * Double(EnrollmentPoseGeometry.yawInnerThreshold))
+                let pitch = base.pitch + Float(jitterY * Double(EnrollmentPoseGeometry.pitchInnerThreshold))
+
+                guard matcher(yaw, pitch, pose, widened) else {
+                    streak = 0; holding = false; holdFrames = 0; continue
+                }
+                if !holding { holding = true; holdFrames = 0 }
+                holdFrames += 1
+                guard holdFrames >= poseHoldFrames else { continue }
+                streak += 1
+                guard streak >= requiredMatchStreak else { continue }
+                streak = 0
+                samples += 1
+            }
+        }
+        return totalFrames
     }
-    func secs(_ v: [Int]) -> String { v.isEmpty ? "never" : String(format: "%.1fs", Double(v.reduce(0,+)) / Double(v.count) / 30.0) }
-    print("   \(label), aiming \(aim)x:")
-    print(String(format: "     now: %@ to enrol, gave up %d/200", secs(nowFrames) as NSString, nowGaveUp))
-    print(String(format: "     was: %@ to enrol, gave up %d/200", secs(wasFrames) as NSString, wasGaveUp))
-}
 
-print("\n\(failures == 0 ? "All checks passed." : "\(failures) check(s) FAILED.")")
-exit(failures == 0 ? 0 : 1)
+    for (label, aim) in [("turns exactly as far as the ring asks", 1.05),
+                         ("overshoots a little", 1.3),
+                         ("overshoots a lot", 1.8)] {
+        var nowF: [Int] = [], wasF: [Int] = []
+        var nowGaveUp = 0, wasGaveUp = 0
+        for seed in 0..<200 {
+            if let f = simulate(matcher: poseMatches, aim: aim, noise: 0.25, seed: UInt64(seed)) { nowF.append(f) } else { nowGaveUp += 1 }
+            if let f = simulate(matcher: legacyPoseMatches, aim: aim, noise: 0.25, seed: UInt64(seed)) { wasF.append(f) } else { wasGaveUp += 1 }
+        }
+        func secs(_ v: [Int]) -> String { v.isEmpty ? "never finished" : String(format: "%.1fs", Double(v.reduce(0, +)) / Double(v.count) / framesPerSecond) }
+        print("   a user who \(label) (\(aim)x):")
+        print(String(format: "     now: %@, gave up %d/200", secs(nowF) as NSString, nowGaveUp))
+        print(String(format: "     was: %@, gave up %d/200", secs(wasF) as NSString, wasGaveUp))
+    }
+
+    print("\n\(failures == 0 ? "All checks passed." : "\(failures) check(s) FAILED.")")
+    exit(failures == 0 ? 0 : 1)
+
+    }
+}


### PR DESCRIPTION
Enrollment is hard to finish, and the diagonals are the reason. This is why:

**The progress ring and the pose gate use different maths.**

`headTurn` normalizes yaw and pitch, then shows the *vector's magnitude* — so the ring reads 100% once the head has turned far enough in the pose's direction. `poseMatches` instead tested yaw and pitch **independently**, each against its own threshold.

For a cardinal pose those agree. For a diagonal they don't. A perfect 45° turn puts 0.707 on each axis: the ring fills to 100%, while each axis is still short of 1.0, so the pose is refused. You have to keep turning roughly **1.41× further than the UI tells you**, with nothing on screen explaining why.

Measured against the real code before the change:

| pose | ring reads 100% at | gate accepted at | |
|---|---|---|---|
| left / top / right / bottom | 1.00 | 1.01 | fine |
| topLeft | 1.00 | 1.41 | **1.41×** |
| topRight | 1.00 | 1.41 | **1.41×** |
| bottomLeft | 0.67 | 0.95 | **1.41×** |
| bottomRight | 0.67 | 0.95 | **1.41×** |

Exactly the four diagonals, exactly √2. I think this is also what c022239 was working around when it hand-tuned `matchLeniency` into the bottom poses — that compensates for the wrong thing, which is why it helped the bottom row and left top-left and top-right untouched.

## The change

Both now read one shared `TurnVector`. A directional pose matches when the magnitude reaches what's required and the compass angle falls inside that pose's own 45° sector. Centre keeps its rectangular box, which was never the problem. `matchLeniency` and `stallWidenFactor` keep their exact meaning — they lower the required magnitude, just as they used to widen the bands — so your bottom-row tuning is preserved.

`headTurn` is behaviourally identical; it just derives from the shared vector now, so the two can't drift apart again.

## Measured

Added `tools/enrollment_selftest.swift`, in the same manual-script style as `liveness_selftest.swift`. It asserts the ring and gate agree at every turn magnitude, that no diagonal costs more than a cardinal, and that a turn satisfies only the sector it points at. Then it simulates enrollment with a noisy yaw/pitch estimate:

| user | before | after |
|---|---|---|
| turns exactly as far as the ring asks | 33.9s, **158 of 200 gave up** | 1.7s, none gave up |
| overshoots by 1.3× | 20.5s | 0.9s |
| overshoots by 1.8× | 0.9s | 0.9s |

The last row is the tell: the old matcher only worked if you *ignored* the indicator and over-rotated. Anyone who trusted the ring got stuck.

Random source is seeded, so runs are reproducible.

## Also in here

The per-axis outer caps become a single magnitude cap (4.5, the stricter of the two originals). `YawBand` and `PitchBand` are removed since `compassAngle` now carries the direction.

Not included, but worth considering separately: enrollment still requires the poses **in a fixed order**, so a head that happens to be at the right pose while the flow is asking for a different one gets nothing. Accepting any not-yet-captured sector, the way Face ID fills its ring, would be the next real improvement.
