### PR TITLE
Put the overlay on the built-in display, not the focused one

### DIFF
--- a/glance/NotchOverlay/NotchGeometry.swift
+++ b/glance/NotchOverlay/NotchGeometry.swift
@@ -193,8 +193,9 @@ struct NotchGeometry {
     /// below can come up implausibly small on odd display configurations.
     private static let minimumNotchWidth: CGFloat = 200
 
+    /// Only a last resort — callers should prefer `preferredScreen()`, which knows where the camera is.
     static func forMainScreen() -> NotchGeometry {
-        guard let screen = NSScreen.main else {
+        guard let screen = NSScreen.screens.first(where: { $0.isBuiltIn }) ?? NSScreen.main else {
             return NotchGeometry(closedSize: pillClosedSize, isPhysicalNotch: false)
         }
         return forScreen(screen)
@@ -217,13 +218,20 @@ struct NotchGeometry {
 
     /// Picks the screen the overlay should show on. If a display is pinned
     /// (`GlanceSettings.preferredDisplayID`), it's used only if still connected — no
-    /// fallback. Otherwise: the physical notch if any display has one, else the primary screen.
+    /// fallback. Otherwise: the physical notch if any display has one, else the built-in display.
     @MainActor
     static func preferredScreen() -> NSScreen? {
         if let targetID = GlanceSettings.shared.preferredDisplayID {
             return NSScreen.screens.first { $0.stableDisplayID == targetID }
         }
-        return NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main
+        if let notched = NSScreen.screens.first(where: { $0.safeAreaInsets.top > 0 }) {
+            return notched
+        }
+        // The built-in display, not `NSScreen.main`. `main` is the screen holding the key window, so on a notchless
+        // MacBook with an external monitor the overlay follows whatever the user last clicked — and it changes between
+        // runs. The camera is on the laptop, so enrollment ends up asking you to turn your head while the instructions
+        // sit on a monitor you cannot look at and face the lens at the same time.
+        return NSScreen.screens.first { $0.isBuiltIn } ?? NSScreen.main
     }
 }
 
@@ -235,5 +243,13 @@ extension NSScreen {
             return nil
         }
         return String(number)
+    }
+
+    /// The Mac's own display — where the built-in camera is pointing out of.
+    var isBuiltIn: Bool {
+        guard let number = deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+            return false
+        }
+        return CGDisplayIsBuiltin(number) != 0
     }
 }


### PR DESCRIPTION
Closes #11.

`preferredScreen()` falls back to `NSScreen.main` when no display has a notch:

```swift
return NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main
```

`NSScreen.main` is **the screen containing the key window**, not the primary display. So on a notchless MacBook — Air M1/M2, 13" Pro, any Intel model — plugged into an external monitor, the overlay goes wherever the user last clicked, and it moves between runs without the user changing anything.

That's the wrong screen by construction, because the camera is on the laptop. During enrollment you get "turn your head to the top right" displayed on a monitor you can't read while facing the lens, which is exactly what #11 describes.

Now falls back to the built-in display, with `NSScreen.main` kept as a last resort for a Mac with no built-in display. A pinned "Display on" choice still wins, unchanged. `forMainScreen()` gets the same treatment.

## On verifying this

I can't reproduce the end-to-end symptom on my own machine: it's a 14" Pro, so it has a notch and `preferredScreen()` resolves through the notch branch and never reaches the fallback. The bug needs a notchless Mac.

What I did confirm here is the mechanism. With both displays attached, `NSScreen.main` reports the built-in display or the external one depending purely on which screen holds focus — I saw it return the external monitor while a window was focused there, and the built-in once focus moved back. On a notchless Mac that value *is* the answer, so the overlay inherits that coin flip.

Anyone with an Air and a monitor could confirm the full symptom in about a minute.
