### PR TITLE
Don't dead-end onboarding when the Accessibility alert won't reappear

### DIFF
--- a/glance/Onboarding/OnboardingController.swift
+++ b/glance/Onboarding/OnboardingController.swift
@@ -666,8 +666,25 @@ final class OnboardingController {
         }
     }
 
+    /// Whether the system alert has been asked for once already this run — see `grantAccessibility`.
+    private var hasRequestedAccessibilityPrompt = false
+
     func grantAccessibility() {
-        KeystrokeInjector.promptForAccessibility()
+        guard !KeystrokeInjector.isAccessibilityTrusted() else {
+            refreshPermissions()
+            return
+        }
+        // `AXIsProcessTrustedWithOptions` raises its alert only while the decision is still undecided. Once the user
+        // has dismissed or denied it — or the app is listed-but-unchecked after a reinstall, a move, or a re-signed
+        // update — it silently returns false and shows nothing. Tapping Grant then does literally nothing, forever,
+        // and Next stays disabled because it waits on `accessibilityGranted`, so onboarding cannot be completed at
+        // all. `grantCamera` already handles the equivalent case by opening System Settings; this mirrors it.
+        guard hasRequestedAccessibilityPrompt else {
+            hasRequestedAccessibilityPrompt = true
+            KeystrokeInjector.promptForAccessibility()
+            return
+        }
+        openSystemSettings(pane: "Privacy_Accessibility")
     }
 
     func grantCamera() {


### PR DESCRIPTION
Likely what #14 is showing (that report is a video with no text, so I can't be certain — but this is a reproducible way to get stuck on exactly that step).

`AXIsProcessTrustedWithOptions` raises its alert **only while the TCC decision is still undecided**. Once the user has dismissed or denied it — or the app is listed-but-unchecked in Privacy & Security after a reinstall, a move to /Applications, or a re-signed update — it silently returns `false` and shows nothing.

`grantAccessibility()` only called that:

```swift
func grantAccessibility() {
    KeystrokeInjector.promptForAccessibility()
}
```

So for any user in that state, tapping **Grant** does nothing at all, with no feedback. And `Next` stays disabled because it waits on `accessibilityGranted`. Onboarding cannot be completed by any route inside the app — the only way out is to know, unprompted, to go to System Settings yourself.

`grantCamera()` already handles the equivalent case correctly:

```swift
if AVCaptureDevice.authorizationStatus(for: .video) == .notDetermined {
    _ = await AVCaptureDevice.requestAccess(for: .video)
    refreshPermissions()
} else {
    openSystemSettings(pane: "Privacy_Camera")
}
```

This mirrors it. The first tap asks for the alert; a later tap, once it's clear no alert is coming, opens Privacy & Security → Accessibility where the user can actually act. Already-trusted short-circuits to a refresh.

The two-step shape is deliberate: `promptForAccessibility()` returns the trust state, not whether the alert was displayed, so there's no way to tell "alert is on screen awaiting an answer" from "alert was suppressed". Jumping straight to System Settings would yank a user away from an alert they were about to accept.
