### PR TITLE
Fix the build-from-source path that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ debug section should appear in the sidebar.
   ```
 2. Open in Xcode:
   ```bash
-   open glance/glance.xcodeproj
+   open glance.xcodeproj
   ```
 3. Run the project:
   - Click `run` or press `Cmd + R`.


### PR DESCRIPTION
Step 1 of **Building from source** already does `cd glance`, so step 2's `open glance/glance.xcodeproj` resolves to `glance/glance/glance.xcodeproj`, which isn't a thing. The project is at the repo root; `glance/` is the source directory.

It's the first command a would-be contributor runs, and it fails.

One character short of a one-line diff.