### PR TITLE
Test every enrolled profile, not just the top-ranked one

### DIFF
--- a/glance/FaceRecognitionPipeline.swift
+++ b/glance/FaceRecognitionPipeline.swift
@@ -141,9 +141,17 @@ extension FaceRecognitionPipeline {
     }
 
     /// Shared by Face Lab and FaceUnlockCoordinator so tuning stays consistent. No runner-up margin check: the same person can be enrolled multiple times under different appearances, so two of their own profiles legitimately score close together — a margin check can't tell that apart from two different people colliding.
+    ///
+    /// Every candidate is tested, not only the top-ranked one. `scored` is ordered by centroid similarity, so the best
+    /// qualifying identity still wins; but ranking first is not the same as qualifying. An identity can lead on
+    /// centroid while failing `maxSampleSimilarity`, or be stale from a previous embedder, and previously either case
+    /// rejected the whole frame even when a lower-ranked profile cleared both thresholds. That is the normal shape of a
+    /// multi-identity enrollment — which the Your Face page actively recommends, for glasses, expressions and lighting.
     nonisolated func bestMatch(in scored: [ScoredIdentity], threshold: Float) -> ScoredIdentity? {
-        guard let first = scored.first, !first.identity.isStale(comparedTo: embedder) else { return nil }
-        guard first.centroidSimilarity >= threshold, first.maxSampleSimilarity >= threshold else { return nil }
-        return first
+        scored.first { candidate in
+            !candidate.identity.isStale(comparedTo: embedder)
+                && candidate.centroidSimilarity >= threshold
+                && candidate.maxSampleSimilarity >= threshold
+        }
     }
 }


### PR DESCRIPTION
`bestMatch` only ever examines `scored.first`:

```swift
guard let first = scored.first, !first.identity.isStale(comparedTo: embedder) else { return nil }
guard first.centroidSimilarity >= threshold, first.maxSampleSimilarity >= threshold else { return nil }
return first
```

Ranking first isn't the same as qualifying. An identity can lead on centroid similarity while failing `maxSampleSimilarity`, or be stale from a previous embedder. Either way the whole frame is rejected, even when a lower-ranked profile clears both thresholds.

That's the normal shape of a multi-identity enrollment — which the Your Face page actively recommends:

> Enroll separate identities to use Glance with multiple people, accessories (ex. glasses), facial expressions, or new lighting environments. This improves recognition quality.

So the documented way to *improve* recognition can make it refuse instead. Wearing glasses, the plain profile can edge ahead on the averaged centroid while its closest individual sample falls short, and the glasses profile that would clear both never gets consulted.

Running the old and new predicates over the same candidate lists, threshold 0.66:

| scenario | before | after |
|---|---|---|
| glasses; plain profile leads centroid 0.68 but max-sample 0.61, glasses profile 0.67 / 0.72 | refused | **Me (glasses)** |
| an identity from a previous model sorts first at 0.91 | refused | **Me** (0.70 / 0.71) |
| single profile, 0.80 / 0.82 | Me | Me |
| nobody close: 0.40 / 0.45 and 0.38 / 0.39 | refused | refused |

`scored` is already ordered by centroid descending, so `first(where:)` keeps "best qualifying identity wins". Single-profile behaviour is unchanged, and a frame nobody matches is still refused — the threshold itself isn't touched.
