### PR TITLE
docs: fix xcodeproj path in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ debug section should appear in the sidebar.
   ```
 2. Open in Xcode:
   ```bash
-   open glance/glance.xcodeproj
+   open glance.xcodeproj
   ```
 3. Run the project:
   - Click `run` or press `Cmd + R`.


### PR DESCRIPTION
## Summary
- The "Building from source" section says to run `open glance/glance.xcodeproj`, but the project file is at the repo root, not inside the `glance/` source folder — following the doc as written fails with "file does not exist".
- Fixes it to `open glance.xcodeproj`.

## Test plan
- [x] Ran `open glance.xcodeproj` from the repo root after a fresh clone and confirmed it opens in Xcode.